### PR TITLE
Feature/better docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ Example of a re-usable HTML component:
 const { Component } = require('@scottjarvis/component');
 
 function Header(state) {
+
   const Header = new Component({ title: "Hello world", ...state });
+
   Header.view = props => `<h1>${props.title}</h1>`;
+
   return Header;
 }
 
@@ -90,20 +93,21 @@ Methods:
 
 - **.setState(obj)**: update the component state, triggers a re-render
 - **.render(el)**: (re)render to the given element on state change (browser)
-- **.tweenState(obj[, cfg])**: set state on each animation frame, supports various easing functions
-- **.view(props)**: receives a state and sets the component view to (re)render
-- **.style(props)**: receives a state and sets the `<style>` to (re)render
-- **.actions(obj)**: creates chainable methods that simplify updating the state
-- **.middleware**: an array of functions that run at the end of setState()
 - **.toString()**: render your component as a string on state change (NodeJS)
+- **.view(props)**: receives a state and sets the component view to (re)render (optional)
+- **.style(props)**: receives a state and sets the `<style>` to (re)render (optional)
+- **.actions(obj)**: chainable methods that simplify updating the state (optional)
+- **.tweenState(obj[, cfg])**: set state on each frame, supports various easings (optional)
+- **.middleware**: an array of functions that run at the end of `setState()` (optional)
 - ...and more
 
 Properties:
 
 - **.state**: an object, contains your app data, read-only - cannot be modified directly
-- **.container**: the HTML Element into which the components view is rendered
+- **.schema**: an object against which to validate your component state (optional) 
+- **.container**: the HTML Element into which the components view is rendered (optional)
 - **.html**: alias of `.container`
-- **.css**: the `<style>` Element which holds the component styles (if set)
+- **.css**: the `<style>` Element which holds the component styles (optional)
 - **.uid**: a unique string, generated once, on creation of a component
 - **.log**: an array containing a history of all component states
 - ...and more
@@ -722,7 +726,7 @@ function Foo(state, schema) {
   const Foo = new Component({ ...defaults, ...state }, schema);
 
   // now let's use `htmel` to construct an HTML view..
-    Foo.view = props => htmel`
+  Foo.view = props => htmel`
     <div style="${props.css}" ${props.attrs}>
       <h2>${props.title}</p>
       <p>${props.text}</p>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Component** is a simple, "stateful component" thing.
 
-It lets you create "functional components" - basically functions that have a "state". 
+It lets you create re-usable, "functional components" - basically functions that have a "state". 
 
 A "state" is a snapshot of your application data at a specific time.
 
@@ -416,7 +416,7 @@ function Foo(state) {
   }
   const Foo = new Component({ ...defaults, ...state })
 
-  // Define chainable "actions" that we cna listen to
+  // Define chainable "actions" that we can listen to
   Foo.actions({
     plus:     props => Foo.setState({ count: Foo.state.count + props }),
     minus:    props => Foo.setState({ count: Foo.state.count - props }),
@@ -696,7 +696,7 @@ htmel`<p onclick="${e => console.log(e.target)}">some text</p>`
 Example usage:
 
 ```js
-const Foo = (state, schema) => {
+Foo(state, schema) {
 
   const defaults = {
     css: {
@@ -744,12 +744,12 @@ const Foo = (state, schema) => {
 Adding linked data to your components is easy - just define it as part of your view:
 
 ```js
-App.view = props => `
-  <div>
-    <script type="application/ld+json">{ ... }</script>
-    ...
-  </div>`
-```
+  Foo.view = props => `
+    <div>
+      <script type="application/ld+json">{ ... }</script>
+      ...
+    </div>`
+  ```
 
 - add a JSON-LD script before your component HTML
 - use the `props` passed in to define/update whatever you need

--- a/README.md
+++ b/README.md
@@ -56,13 +56,10 @@ A "state" is a snapshot of your application data at a specific time.
 ```js
 const { Component } = require('@scottjarvis/component');
 
-// Define a state
-const state = { title: "Hello world", txt: "foobar" }
-
 // Define your component:
 
-// 1. create it, pass in the state 
-const App = new Component(state)
+// 1. create it, pass in the initial state 
+const App = new Component({ title: "Hello world", txt: "foobar" })
 
 // 2. define a view
 App.view = props => `
@@ -290,9 +287,9 @@ App.style = (props) => `
 `
 ```
 
-If a component is added to a page with `render('.container')`, the CSS above is prefixed with the `id` or `className` of its container. 
+If a component is added to a page with `render('.container')`, the CSS is prefixed with the `id` or `className` of its container. 
 
-_This CSS automatic "scoping"/prefixing will (usually) prevent your component styles affecting other parts of the page_.
+_This CSS "auto-scoping" will prevent a components styles affecting other parts on the page_.
 
 It also keeps your component CSS clean - no need to prefix anything with a unique ID or class yourself.
 
@@ -411,6 +408,25 @@ App.minus(1)
 ```
 
 Also see [examples/usage-emitter.js](examples/usage-emitter.js)
+
+### Attaching Events
+
+To add your own standard JavaScript Events, you should add them to the container of your components:
+
+```js
+App.render('.container');
+
+App.html.addEventListener("click", e => {
+    // get the element clicked
+    const el = e.target.className;
+    // work out what to do next
+    if (el === "foo") {
+      // ...
+    } else if (el === "bar") {
+      // ...
+    }
+});
+```
 
 ### Using the `tweenState` module
 
@@ -576,14 +592,12 @@ var TableRows = props => props.map(row =>
     ${row.map((item, i) => `<td>${row[i]}</td>`)}
   </tr>`);
 
-var Table = props =>
-  html`<div>
-    <table>
+var Table = props => html`
+  <table>
     <tbody>
       ${TableRows(props.data)}
     </tbody>
-    </table>
-  </div>`;
+  </table>`;
 ```
 
 Features of `htmel`:

--- a/README.md
+++ b/README.md
@@ -696,7 +696,8 @@ htmel`<p onclick="${e => console.log(e.target)}">some text</p>`
 Example usage:
 
 ```js
-Foo(state, schema) {
+// Let's define a component with a view, using `htmel`
+function Foo(state, schema) {
 
   const defaults = {
     css: {
@@ -721,8 +722,7 @@ Foo(state, schema) {
   const Foo = new Component({ ...defaults, ...state }, schema);
 
   // now let's use `htmel` to construct an HTML view..
-  
-  Foo.view = props => htmel`
+    Foo.view = props => htmel`
     <div style="${props.css}" ${props.attrs}>
       <h2>${props.title}</p>
       <p>${props.text}</p>

--- a/README.md
+++ b/README.md
@@ -409,9 +409,9 @@ App.minus(1)
 
 Also see [examples/usage-emitter.js](examples/usage-emitter.js)
 
-### Attaching Events
+### Attaching Event Listeners
 
-To add your own standard JavaScript Events, you should add them to the container of your components:
+To add your own Event Listeners, you should add them to the container of your components:
 
 ```js
 App.render('.container');

--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ A "state" is a snapshot of your application data at a specific time.
 ## Quickstart
 
 ```js
-{ Component } = require('@scottjarvis/component');
+const { Component } = require('@scottjarvis/component');
 
 // Define a state
-var state = { title: "Hello world", txt: "foobar" }
+const state = { title: "Hello world", txt: "foobar" }
 
 // Define your component:
 
 // 1. create it, pass in the state 
-var App = new Component(state)
+const App = new Component(state)
 
 // 2. define a view
 App.view = props => `

--- a/examples/usage-in-browser--table.html
+++ b/examples/usage-in-browser--table.html
@@ -5,48 +5,52 @@
 <script src="../dist/component.min.js"></script>
 <script src="../dist/htmel.min.js"></script>
 <script>
-  // define the component
+// Define a re-usable component
+// Just create a function that creates a new Component, and returns it:
+function Table(state, schema) {
 
-  var state = {
-    title: "Title goes here",
-    subTitle: "Sub-title goes here",
-    attrs: {
-      "class": "foo bar",
-      "z-index": 2,
-    },
+  const defaults = {
     css: {
       "font-weight": "bold",
       "color": "red",
-      unused: {
-        "font-size": "2em",
-      },
     },
+    attrs: {
+      width: "100%",
+      "border": 0,
+    },
+    title: "Title goes here",
+    subTitle: "Click me and check the dev tools console",
     headings: [ "Country", "0-10", "11-20", "21-30", "31-40", "older" ],
     content: [
       [ "England", 10, 20, 30, 20, 20 ],
       [ "France",  10, 20, 30, 30, 10 ],
       [ "Germany", 1, 2, 3, 3, 1 ],
     ],
-    source: null
+    source: false,
+    onclick: e => console.log("CLICKED!", e.target),
   };
 
-  var Table = new Component(state);
+  // Create the component to return
+  const Table = new Component({ ...defaults, ...state }, schema);
 
-  var TableRows = props => props.map(row =>
-    htmel`<tr>
-      ${row.map((item, i) => `<td>${row[i]}</td>`)}
-    </tr>`);
+  const TableRows = props => props.map(row =>
+    htmel`<tr>${row.map((item, i) => `<td>${row[i]}</td>`)}</tr>`);
 
-  Table.view = props =>
-    htmel`<div ${props.attrs}>
-      <h2>${props.title}</h2>
-      <p style="${props.css}">${props.subTitle}</p>
-      <table>
+  Table.view = props => htmel`
+    <div>
+      <h2 style="${props.css}">${props.title}</h2>
+
+      <p onclick="${props.onclick}">
+        ${props.subTitle}
+      </p>
+      <table ${props.attrs}>
       <thead>
-        <tr>${props.headings.map(h => `<td>${h}</td>`)}</tr>
+        <tr>
+          ${props.headings.map(h => `<td>${h}</td>`)}
+        </tr>
       </thead>
       <tbody>
-        ${TableRows(props.content)}
+          ${TableRows(props.content)}
       </tbody>
       </table>
       ${props.source && `<p>Source: ${props.source}</p>`}
@@ -55,41 +59,42 @@
   Table.style = props => `
     table { display: table; }
     thead { font-weight: bold; }
-    td { min-width: 50px; padding: 4px; border: 1px solid grey; }
-    `;
+    td { min-width: 50px; padding: 4px; border: 1px solid grey; }`;
+
+  Table.middleware = [ props => console.log("MIDDLEWARE", props.title, Table.uid) ]
 
   Table.actions({
-    add: props => Table.setState({ content: [ ...Table.state.content, props] })
-  });
+    add: props => Table.setState({ content: [ ...Table.state.content, props ] })
+  })
 
+  return Table;
+}
 </script>
 </head>
 
 <body>
-  <div>
-    <div class="table"></div>
-    <button id="add-more" onclick="Table.addRow()">Add row</button>
+
+  <div class="demo">
+    <div class="table1"></div>
+    <div class="table2"></div>
+    <div class="table3"></div>
   </div>
 
   <script>
-  // add component to page
-  Table.render('.table');
-  // update the component
-  Table({ title: "Awesome Table" });
-  Table.add([ "USA", 61, 32, 83, 14, 56 ]);
-  Table.add([ "Japan", 1, 2, 3, 4, 5 ]);
-  Table.add([ "China", 12, 23, 344, 42, 245 ]);
+  // now we can create lots of re-usable components
+  var table1 = new Table({ title: "table 1" });
+  var table2 = new Table({ title: "table 2" });
+  var table3 = new Table({ title: "table 3" });
 
-  // use event delegation to add user interactivity (recommended)
-  Table.html.addEventListener("click", e => {
-    var el = e.target.nodeName.toLowerCase();
-    console.log(`You clicked a  <${el}>  element.`);
-  });
+  table1.render('.table1');
+  table2.render('.table2');
+  table3.render('.table3');
 
-  // ..or add your own methods to the component
-  Table.addRow = e => Table.add([ "Buttonland", 12, 23, 344, 42, 245 ]);
-
+  table1.add(["Added to ONE",   23, 20, 47,  7, 0])
+  table2.add(["Added to TWO",    0, 32, 40, 91, 0])
+  table3.add(["Added to THREE", 20, 40, 60, 20, 0])
   </script>
+
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,9 +210,9 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+			"integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
 			"dev": true,
 			"optional": true
 		},
@@ -370,12 +370,12 @@
 			}
 		},
 		"rollup": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.23.0.tgz",
-			"integrity": "sha512-vLNmZFUGVwrnqNAJ/BvuLk1MtWzu4IuoqsH9UWK5AIdO3rt8/CSiJNvPvCIvfzrbNsqKbNzPAG1V2O4eTe2XZg==",
+			"version": "2.38.4",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.4.tgz",
+			"integrity": "sha512-B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==",
 			"dev": true,
 			"requires": {
-				"fsevents": "~2.1.2"
+				"fsevents": "~2.3.1"
 			}
 		},
 		"rollup-plugin-terser": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@rollup/plugin-commonjs": "^14.0.0",
 		"@rollup/plugin-node-resolve": "^8.4.0",
 		"@scottjarvis/validator": "^1.0.2",
-		"rollup": "^2.23.0",
+		"rollup": "^2.38.4",
 		"rollup-plugin-terser": "^6.1.0"
 	},
 	"bugs": {


### PR DESCRIPTION
Re-write the docs to show how to create _re-usable_ components, 
not just demonstrate the `Compontent()` API. This change mostly 
involved wrapping the existing code in a function that returns the 
component being defined.
