### PR TITLE
[WIP] Feature/charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2061,11 +2061,16 @@ Here's a minimal example showing how to make a chart:
   // ..now define it's view, where we draw our chart:
 
   Foo.view = (props, ctx) => {
-
     // Pass in your data, an array of objects for bar/pie/candle charts, or 
     // an object of arrays (more useful for grouped bar charts & line charts):
 
-    ctx.useData({
+    ctx.clear()
+
+    .size(props.width, props.height) 
+
+    .margin(40,80,170,80)  // top, bottom, left, right
+
+    .useData({
       'Dollars':
       [
         { year: 2000, open: 3, close: 5, low: 2, high: 6 },
@@ -2075,24 +2080,23 @@ Here's a minimal example showing how to make a chart:
         // ...
       ],
     })
-    .margin(40,80,170,80)  // top, bottom, left, right
-    .setStyle({
-      font: 'Normal 1em Sans-Serif',
-    })
+
     .xAxis({
       range: [1999,2007],
       scale: 1,
       label: "Years",
       tickLength: -3,
     })
+
     .yAxis({
       range: [0,500],
       scale: 5,
       label: "Dollars",
       tickLength: -3,
     })
-    .drawEach( (currency, name, i) => {
-      currency.forEach((data, n) => {
+
+    .drawEach(currency => {
+      currency.forEach(data => {
         data.candle({
           open: data.open,
           close: data.close,
@@ -2100,9 +2104,9 @@ Here's a minimal example showing how to make a chart:
           low: data.low,
         })
       });
-    })
+    });
+
   };
-  
 ```
 
 To see more about `Chart` with `Component`, see [examples/usage-Chart.html](examples/usage-Chart.html).

--- a/README.md
+++ b/README.md
@@ -2129,6 +2129,12 @@ Here's a minimal example, of a simple "candlestick" chart:
   };
 ```
 
+Some very basic examples/demos:
+
+<p align="center">
+  <img align="center" src="https://i.imgur.com/yaAXLdv.gif" alt="Chart demos" />
+</p>
+
 To see more about using `Chart`, see [examples/usage-Chart.html](examples/usage-Chart.html).
 
 ## Using the "React hooks" module

--- a/README.md
+++ b/README.md
@@ -2051,7 +2051,28 @@ const { Chart } = require('@scottjarvis/component');
 
 ### Usage:
 
-Here's a minimal example showing how to make a chart:
+Here's how it works, generally:
+
+- define a canvas size
+- define the margins around your "chart area"
+- pass in some data to use
+- define X and Y axes
+  - min and max values of axis
+  - labels and tick values
+  - styling, positioning, etc
+- use the `drawEach()` method to draw your chart:
+  - loop over your data to access each data point
+  - each data point is decorated with various drawing methods:
+    - `data.bar({ opts })` - draw bars
+    - `data.line({ opts })` - draw lines and filled areas, smoothed or not
+    - `data.circle({ opts })` - draw circles and circle segments around the chart
+    - `data.pie({ opts })` - draw a segment of a full, single circle
+    - `data.arc({ opts })` - draw a segment of a single arc (partial circle) 
+    - `data.candle({ opts })` - draw a candle stick (box and line, red or green)
+
+You only pass in the options/attributes you want to join to your data, and ignore the others - each drawing method will try to work out the rest, based on your margins and axes settings.
+
+Here's a minimal example, of a simple "candlestick" chart:
 
 ```js
   // enable the add-on:
@@ -2061,15 +2082,14 @@ Here's a minimal example showing how to make a chart:
   // ..now define it's view, where we draw our chart:
 
   Foo.view = (props, ctx) => {
-    // Pass in your data, an array of objects for bar/pie/candle charts, or 
-    // an object of arrays (more useful for grouped bar charts & line charts):
-
     ctx.clear()
 
     .size(props.width, props.height) 
 
     .margin(40,80,170,80)  // top, bottom, left, right
 
+    // Pass in your data, an array of objects for bar/pie/candle charts, or 
+    // an object of arrays (more useful for grouped bar charts & line charts):
     .useData({
       'Dollars':
       [
@@ -2109,7 +2129,7 @@ Here's a minimal example showing how to make a chart:
   };
 ```
 
-To see more about `Chart` with `Component`, see [examples/usage-Chart.html](examples/usage-Chart.html).
+To see more about using `Chart`, see [examples/usage-Chart.html](examples/usage-Chart.html).
 
 ## Using the "React hooks" module
 

--- a/README.md
+++ b/README.md
@@ -2056,8 +2056,8 @@ Here's how it works, generally:
 - define a canvas size
 - define the margins around your "chart area"
 - pass in some data to use
-- define X and Y axes
-  - min and max values of axis:
+- define X and Y axes:
+  - min and max values of axis
   - labels and tick values
   - styling, positioning, etc
 - use the `drawEach()` method to draw your chart:

--- a/README.md
+++ b/README.md
@@ -2002,7 +2002,7 @@ For a full usage example, see [examples/usage-Geo.html](examples/usage-Geo.html)
 
 ## Using the `Chart` module
 
-The `Chart` add-on let's you draw charts & graphs to the canvas, using the a chainable API (kinda) similar to `d3`. 
+The `Chart` add-on let's you draw charts & graphs to the canvas, using a chainable API similar to `d3`. 
 
 It's only 3.5kb, minified & gzipped.
 

--- a/README.md
+++ b/README.md
@@ -2057,12 +2057,12 @@ Here's how it works, generally:
 - define the margins around your "chart area"
 - pass in some data to use
 - define X and Y axes
-  - min and max values of axis
+  - min and max values of axis:
   - labels and tick values
   - styling, positioning, etc
 - use the `drawEach()` method to draw your chart:
-  - loop over your data to access each data point
-  - each data point is decorated with various drawing methods:
+  - it loops over your data, giving access to each data point
+  - each data point is "decorated" with various drawing methods:
     - `data.bar({ opts })` - draw bars
     - `data.line({ opts })` - draw lines and filled areas, smoothed or not
     - `data.circle({ opts })` - draw circles and circle segments around the chart
@@ -2070,7 +2070,7 @@ Here's how it works, generally:
     - `data.arc({ opts })` - draw a segment of a single arc (partial circle) 
     - `data.candle({ opts })` - draw a candle stick (box and line, red or green)
 
-You only pass in the options/attributes you want to join to your data, and ignore the others - each drawing method will try to work out the rest, based on your margins and axes settings.
+You need only pass in the options/attributes you want to join to your data and ignore the others - each drawing method will try to work out the rest, based on your margins and axes settings. However, there as some positioning and styling options available for each drawing method.
 
 Here's a minimal example, of a simple "candlestick" chart:
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A "state" is a snapshot of your application data at a specific time.
   - [`useAudio`](#using-the-useaudio-module): add dynamic audio to your components (uses Web Audio API)
   - [`onLoop`](#using-the-onloop-module): a fixed-interval loop, suitable for games, animations, time-dependant stuff
   - [`geo`](#using-the-geo-module): an easy way to create Mercator or Robinson projected world maps
+  - [`chart`](#using-the-chart-module): an easy way to create charts, graphs and plotting things
   - [`react-hooks`](#using-the-react-hooks-module): an alternative, more React-like API add-on
   - [`devtools`](#using-the-devtools-module): enables easier component debugging in the browser
 
@@ -1998,6 +1999,113 @@ Here's an example map:
 ![Robinson map](https://user-images.githubusercontent.com/2726610/139452315-f6cb21b2-cca4-4e88-b647-a69e50ce82ed.png)
 
 For a full usage example, see [examples/usage-Geo.html](examples/usage-Geo.html).
+
+## Using the `Chart` module
+
+The `Chart` add-on let's you draw charts & graphs to the canvas, using the a chainable API (kinda) similar to `d3`. 
+
+It's only 3.5kb, minified & gzipped.
+
+It supports these chart types:
+
+- scatter charts
+- bubble charts
+- line charts
+- area charts (layered & stacked)
+- bar charts (horizontal & vertical)
+- grouped bar charts (horizontal & vertical)
+- stacked bar charts (horizontal & vertical)
+- candlestick charts
+- pie & doughnut charts
+- arc or "gauge" charts
+- lollipop charts
+- mixed charts
+
+It can work standalone, without `Component` being installed.
+
+### In browsers:
+
+```html
+<script src="https://unpkg.com/@scottjarvis/component/dist/chart.min.js"></script>
+<script>
+// use it here
+</script>
+```
+
+### In ES6:
+
+```js
+import { Chart } from '@scottjarvis/component';
+
+// use it here
+```
+
+### In NodeJS:
+
+```js
+const { Chart } = require('@scottjarvis/component');
+
+// use it here
+
+```
+
+### Usage:
+
+Here's a minimal example showing how to make a chart:
+
+```js
+  // enable the add-on:
+  Component.Ctx = Chart;
+
+  // ..create a component as usual, 
+  // ..now define it's view, where we draw our chart:
+
+  Foo.view = (props, ctx) => {
+
+    // Pass in your data, an array of objects for bar/pie/candle charts, or 
+    // an object of arrays (more useful for grouped bar charts & line charts):
+
+    ctx.useData({
+      'Dollars':
+      [
+        { year: 2000, open: 3, close: 5, low: 2, high: 6 },
+        { year: 2001, open: 5, close: 6, low: 2, high: 6 },
+        { year: 2002, open: 6, close: 3, low: 2, high: 4 },
+        { year: 2003, open: 3, close: 4, low: 1, high: 8 },
+        // ...
+      ],
+    })
+    .margin(40,80,170,80)  // top, bottom, left, right
+    .setStyle({
+      font: 'Normal 1em Sans-Serif',
+    })
+    .xAxis({
+      range: [1999,2007],
+      scale: 1,
+      label: "Years",
+      tickLength: -3,
+    })
+    .yAxis({
+      range: [0,500],
+      scale: 5,
+      label: "Dollars",
+      tickLength: -3,
+    })
+    .drawEach( (currency, name, i) => {
+      currency.forEach((data, n) => {
+        data.candle({
+          open: data.open,
+          close: data.close,
+          high: data.high,
+          low: data.low,
+        })
+      });
+    })
+  };
+  
+```
+
+To see more about `Chart` with `Component`, see [examples/usage-Chart.html](examples/usage-Chart.html).
 
 ## Using the "React hooks" module
 

--- a/examples/usage-Chart.html
+++ b/examples/usage-Chart.html
@@ -19,7 +19,7 @@
 
 <script>
   let frame = 1; // frame count
-  const colors = [ 'red', 'blue' ];
+  const colors = [ 'rgba(255,0,0, 0.5)', 'rgba(0,0,255, 0.5)' ];
 
   // Enable our Chart addon, it'll create an extended 2dContext,
   // with a chainable API, and these extra methods:
@@ -32,27 +32,26 @@
   //
   Component.Ctx = Chart;
 
-
   // define a new component
-  const Foo = new Component({ x: 280, y: 100 });
-  // define a "view", that draws to the components canvas
-  Foo.view = (props, ctx) => {
+  const myChart = new Component({ x: 280, y: 100 });
+
+  // define the "view", that draws to the components canvas
+  myChart.view = (props, ctx) => {
+
     if (frame === 1) {
-      context = ctx;
       // set the canvas size (w, h, aspectRatio)
-      ctx.size(600, 480)           // set width and height, ignore aspect ratio
+      ctx.size(640,480)           // set width and height, ignore aspect ratio
       //ctx.size(640, 480, null)   // same as above
-      //ctx.size(null, 480, 4/3)   // set as 4:3,  grow till height = 480
+      //ctx.size(null, 480, 4/3)   // set as 4:3,  grow till height = 4.0
       //ctx.size(null, 480, 16/9)  // set as 16:9, grow till height = 480
       //ctx.size(640, null, 3/4)   // set as 4:3, crop till width = 640
       //ctx.size(640, null, 9/16)  // set as 16:9, crop till width = 640
-      console.clear();
+      //console.clear();
     }
 
 
-    ctx.clear()  // using `clear(true)` will clear transforms too
+      ctx.beginPath()
 
-      .beginPath()
       .data({
         'USA': [{},
           { year: 2000, medals: 25 },
@@ -73,49 +72,52 @@
           { year: 2006, medals: 21 },
         ]
       })
-      .margin(40,80,120,60)  // top, bottom, left, right
-      .yAxis([1999,2007], 1, -6, 'Year', true)        // range, scale, tickSize, label
-      .xAxis([0,50],      5, -6, 'Gold Medals', false) // range, scale, tickSize, label, centerLabels
+      .margin(50,60,120,40)  // top, bottom, left, right
+      .xAxis([1999,2007], 1, -6, 'Year', true)  // range, scale, tickSize, label, centeredLabels
+      .yAxis([0,50],      5, -6, 'Gold Medals') // range, scale, tickSize, label
       .each((country, key, i) => {
-        // here you can draw a legend, or whatever..
-        //
+        // Now we can work with our "decorated" chart data, ${country}.
+        // Work with your top-level data here, like draw a legend..
 
+        // Now lets go over each bit of data for this country
         country.forEach(data => {
+          // Note, ${data} has .bar(), .rect(), and .line() methods added,
+          // which try to draw "ready-made" shapes, in the right place.
+
           if (!data.medals && data.medals !== 0) return;
 
-          // here you can draw your data:
-          // define only the attributes you need
+          // You should only define the attrs you want "joined" to your
+          // data - and don't override any others.
 
           data.bar({
-            //height: data.medals,
-            width: data.medals,
+            height: data.medals,
+            //width: data.medals,
             fill: colors[i]
-          })
+          });
 
           data.circle({
-            //cy: data.medals,
-            cx: data.medals,
-            cr: 3,
+            cy: data.medals,
+            //cx: data.medals,
+            cr: 5,
             fill: colors[i]
-          })
+          });
 
-          data.lines({
-            //px: data.medals,
+          data.line({
             py: data.medals,
+            //px: data.medals,
             stroke: colors[i]
-          })
+          });
 
-          // ..etc
         });
 
-      })
+      });
 
       frame++;
   };
 
 
   // render to a canvas, and attach its context (`ctx`) to our component
-  Foo.render('.container', '2d');
+  myChart.render('.container', '2d');
 
 </script>
 </body>

--- a/examples/usage-Chart.html
+++ b/examples/usage-Chart.html
@@ -18,81 +18,19 @@
   <canvas class="container"></canvas>
 
 <script>
-
-
-
-const isFn = v => typeof v ==='function';
-const isArray = v => Array.isArray(v);
-const isDate = v => isFn(v.getDay);
-const isDateRange  = r => isDate(r[0]) && isDate(r[1]);
-const getDateRange = r => (new Date(r[0])-new Date(r[1]))/864e5|0;
-const fillRange = (num1, num2, steps = 1) => Array(Math.abs(num1-num2/steps)+1).fill(num1).map((v,i)=>v+(i*steps)*(num1>num2?-1:1));
-// example usage
-const myRange = [ new Date('2021-01-01'), new Date('2021-01-31') ];
-const dateRange = Math.abs(getDateRange(myRange));
-//console.log('dateRange', dateRange);
-//console.log('fillRange(0,100)', fillRange(0,100,5));
-//console.log('......');
-
-// Not tested/used yet:
-
-// interpolate dates, from https://github.com/d3/d3-interpolate/blob/main/src/date.js
-const interpolateDate = (a, b) => {
-  const d = new Date;
-  return a = +a,
-         b = +b,
-         (t) => d.setTime(a*(1-t)+b*t),
-         d;
-}
-
-// interpolate string stuff.. use with fillRange()
-const numbers = "1st Jan 2001".match(/[0-9]*/g);        //   returns ["1", "", "", "", "", "", "", "", "2001", ""]
-const chars = "1st Jan 2001".match(/[A-Za-z ,\.]*/g)    //   returns ["", "st Jan ", "", "", "", "", ""]
-numbers.map((n, i) => n.length>0 ? `${n}${chars[i+1]||''}` : ''); // returns ["1st Jan ", "", "", "", "", "", "", "", "2001", ""]
-
-
-
-// Data stuff:
-//
-// Functions for working with Objects:
-//
-// Given the object `{ name: "Bob" }`, returns an object like  `{ key: "name", value: "Bob" }`
-const objToKeyValuePairs = obj => Object.keys(obj).map((key) => ({ key, value: obj[key] }));
-//
-//
-// Functions for working with Arrays of Objects:
-//
-// Converts an array of objects into an array of objects containing key/value pairs
-const toKeyValuePairs = array => array.map(obj => objToKeyValuePairs(obj));
-// Given an array of objects, returns an object "keyed" by the given `prop` value
-const toKeyedObject = (array, key, obj = {}) => { array.forEach(item => obj[item[key]] = item); return obj; };
-// Sort an array of objects by the given object `prop` - returns an array,
-const sortByKey = (array, prop, order = 'asc') => [...array].sort((a, b) => order === 'asc' ? a[prop]-b[prop] : b[prop]-a[prop]);
-const sortByKeyAsc = (array, prop) => sortByKey(array, prop, 'asc');
-const sortByKeyDesc = (array, prop) => sortByKey(array, prop, 'desc');
-// Get the combined total value of the given object property, in an array of objects,
-// note that each object in the array must contain the given property (`prop`)
-const getSumTotal = (array, prop) => array.reduce((prev, cur) => prev + cur[prop], 0);
-// Get the min/max value of the given `prop` from objects in the given `array` of objects
-const getMinOrMaxValue = (array, prop, which) => Math[which](...array.map(obj => obj[prop]));
-// Get the min value of the given `prop` from objects in the given `array` of objects
-const getMinValue = (array, prop) => getMinOrMaxValue(array, prop, 'min');
-// Get the max value of the given `prop` from objects in the given `array` of objects
-const getMaxValue = (array, prop) => getMinOrMaxValue(array, prop, 'max');
-// Get the object from `array` that has the lowest or highest value for `prop`
-const getObjectWithMinOrMaxValue = (array, prop, which) => array.reduce((max, obj) => which === 'min' ? max[prop]<obj[prop]?max:obj : max[prop]>obj[prop]?max:obj);
-// Get the object from `array` that has the lowest value for `prop`
-const getObjectWithMinValue = (array, prop) => getObjectWithMinOrMaxValue(array, prop, 'min');
-// Get the object from `array` that has the highest value for `prop`
-const getObjectWithMaxValue = (array, prop) => getObjectWithMinOrMaxValue(array, prop, 'max');
-
-
-// =============================================================================
-
-
-
   let frame = 1; // frame count
-  const colors = [ 'red', 'lightblue', 'lightgreen', 'orange', 'pink', 'limegreen', 'magenta', 'grey', 'cyan' ];
+  const colors = [
+    '#FF4136',
+    '#0074D9',
+    '#B10DC9',
+    '#2ECC40',
+    '#FF851B',
+    '#F012BE',
+    '#FFDC00',
+    '#39CCCC',
+    '#85144b',
+    '#01FF70',
+  ];
 
   // Enable our Chart addon, it'll create an extended 2dContext,
   // with a chainable API, and these extra methods:
@@ -126,43 +64,64 @@ const getObjectWithMaxValue = (array, prop) => getObjectWithMinOrMaxValue(array,
 
     ctx.clear()
 
+    .translate(0.5,0.5) // crisp lines trick
+
 
     // Pass in your data, an array of objects for simple bar charts, or
     // (more useful for grouped bar charts & line charts) an object of arrays:
-    .data({
+    .useData({
       'USA':
-      [ {},
-        { medals: 19 },
-        { medals: 30 },
-        { medals: 23 },
-        { medals: 25 },
-        { medals: 12 },
-        { medals: 16 },
-        { medals: 23 },
+      [{}, // padded data trick - mainly for bar charts, to give more "space" from axis
+        { year: 2000, medals: 7, open: 3, close: 5, low: 2, high: 6 },
+        { year: 2001, medals: -5, open: 5, close: 6, low: 2, high: 6 },
+        { year: 2002, medals: 5, open: 6, close: 3, low: 2, high: 4 },
+        { year: 2003, medals: -7, open: 3, close: 4, low: 1, high: 8 },
+        { year: 2004, medals: -4, open: 4, close: 3, low: 1, high: 5 },
+        { year: 2005, medals: 6, open: 3, close: 5, low: 2, high: 6 },
+        { year: 2006, medals: 8, open: 5, close: 6, low: 2, high: 6 },
       ],
-      'UK':
-      [ {},
-        { medals: 10 },
-        { medals: 9  },
-        { medals: 18 },
-        { medals: 18 },
-        { medals: 15 },
-        { medals: 21 },
-        { medals: 24 },
-      ]
     })
 
-    .margin(40,80,130,80)  // top, bottom, left, right
+    .margin(40,80,170,80)  // top, bottom, left, right
 
-    .xAxis([1999,2007],  1, 0, -4, "Years", true, true, []) // range, scale, yPos(%), tickSize(%), name, nameBelow, tickLabelsCentered, tickLabels
-    .yAxis([0,     50],  5, 0, -2, "Gold Medals", true, []) // range, scale, xPos(%), tickSize(%), name, namelLeft, tickLabels
+    .setStyle({
+      font: 'Normal 1em Sans-Serif',
+    })
 
-    .drawEach((country, name, i) => {
+    .xAxis({
+      range: [-10,10],
+      scale: 2,
+      label: "",
+      labelBelow: true,
+      yPos: 0,
+      tickLength: 100,
+      tickCentered: true,
+      tickLabelCentered: true,
+      //tickLabels: (label, i) => (i === 0 || i === 8) ? '' : label, // hide first or last label
+      tickLabels: label => label === -1 ? '' : label,
+      style: {
+        lineWidth: 5,
+        strokeStyle: 'red',
+      }
+    })
+
+    .yAxis({
+      range: [-10,10],
+      scale: 2,
+      label: ``,
+      labelLeft: true,
+      xPos: 0,
+      tickLength: 100,
+      tickCentered: true,
+      //tickLabels: label => label === -1 ? '' : label,
+    })
+
+    .drawEach( (country, name, i) => {
       // Now we can work with some "decorated" chart data, ${data}.
       // You might wanna use your top-level ${data} here - e.g. to draw a legend
 
       // Also available, just FYI:
-      //const { x, y, h, w, margin, xRange, yRange, xScale, yScale, xDistance, yDistance } = ctx.dimensions();
+      const { x, y, h, w, margin, xRange, yRange, xScale, yScale, xDistance, yDistance } = ctx.dimensions();
       // Do whatever you like with these params, if anything..
       //    x/y         = the x/y origins of the chart area, accounting for margins
       //    w/h         = the x/y end points of the chart area, accounting for margins
@@ -175,47 +134,55 @@ const getObjectWithMaxValue = (array, prop) => getObjectWithMinOrMaxValue(array,
       country.forEach((data, n) => {
         // You should only define the attrs you want "joined" to your
         // data - and don't override any others!
-        data.bar({
-          height: data.medals,
-          fill: colors[i],
-        });
+
+        //data.bar({
+        //  height: data.medals,
+        //  stacked: false,
+        //  style:{ fill: colors[i] },
+        //});
         data.circle({
           cy:     data.medals,
-          radius: data.medals/2,
-          fill:   colors[i],
+          radius: Math.abs(data.medals*2),
           start: 0,
           end: 360,
           rotate: 0,
+          style: { fill: colors[n], lineWidth: 2, stroke: colors[n+1] },
         });
-        data.line({
-          py:        data.medals,
-          stroke:    colors[i],
-          lineWidth: 3,
-        });
+        //data.pie({
+        //  px: 0,
+        //  py: 0,
+        //  slice: data.medals,
+        //  radius: 100,
+        //  innerRadius: 70,
+        //  style: { fill: colors[n] },
+        //});
+        //data.arc({
+        //  slice: data.medals,
+        //  radius: 100,
+        //  innerRadius: 70,
+        //  style: { fill: colors[n] },
+        //});
+        //data.line({
+        //  py: data.medals,
+        //  stacked: true,
+        //  smooth: true,
+        //  style: {
+        //    fill: colors[i],
+        //    stroke: colors[i],
+        //    lineWidth: 2,
+        //  },
+        //});
+        //data.candle({
+        //  open: data.open,
+        //  close: data.close,
+        //  high: data.high,
+        //  low: data.low,
+        //  style: {
+        //    lineWidth: 1,
+        //  }
+        //})
       });
     })
-
-    // ..or change data and add a pie chart
-    .data([
-      { medals: 5 },
-      { medals: 30 },
-      { medals: 10 },
-      { medals: 100 },
-    ])
-    .drawEach(item => {
-      item.forEach((data, i) => {
-        data.pie({
-          slice:  data.medals, // turns into a % of 360 degrees
-          fill: colors[i],
-          px: 420,
-          py: 100,
-          radius: 60,
-        });
-      });
-    })
-
-
-
 
     frame++;
   };

--- a/examples/usage-Chart.html
+++ b/examples/usage-Chart.html
@@ -73,41 +73,34 @@
         ]
       })
       .margin(50,60,120,40)  // top, bottom, left, right
-      .xAxis([1999,2007], 1, -6, 'Year', true)  // range, scale, tickSize, label, centeredLabels
-      .yAxis([0,50],      5, -6, 'Gold Medals') // range, scale, tickSize, label
+      .xAxis([1999,2007], 1, -1.5, 'Year', true, true)  // range, scale, tickSize (%), labelText, labelAlignCenter, labelAlignBelow
+      .yAxis([0,50],      5, -1.5, 'Gold Medals', true) // range, scale, tickSize (%), labelText, labelAlignLeft
       .each((country, key, i) => {
         // Now we can work with our "decorated" chart data, ${country}.
-        // Work with your top-level data here, like draw a legend..
+        // Use your top-level data here - to draw a legend, for example..
 
         // Now lets go over each bit of data for this country
         country.forEach(data => {
+          if (!data.medals && data.medals !== 0) return;
           // Note, ${data} has .bar(), .rect(), and .line() methods added,
           // which try to draw "ready-made" shapes, in the right place.
-
-          if (!data.medals && data.medals !== 0) return;
-
+          //
           // You should only define the attrs you want "joined" to your
           // data - and don't override any others.
-
           data.bar({
-            height: data.medals,
-            //width: data.medals,
+            height: data.medals, // (swap xAxis and yAxis above, then use "width")
             fill: colors[i]
           });
-
           data.circle({
-            cy: data.medals,
-            //cx: data.medals,
+            cy: data.medals,    // (swap xAxis and yAxis above, then use "cx")
             cr: 5,
             fill: colors[i]
           });
-
           data.line({
-            py: data.medals,
-            //px: data.medals,
-            stroke: colors[i]
+            py: data.medals,    // (swap xAxis and yAxis above, then use "py")
+            stroke: colors[i],
+            lineWidth: 3,
           });
-
         });
 
       });

--- a/examples/usage-Chart.html
+++ b/examples/usage-Chart.html
@@ -18,8 +18,83 @@
   <canvas class="container"></canvas>
 
 <script>
+
+
+
+const isFn = v => typeof v ==='function';
+const isArray = v => Array.isArray(v);
+const isDate = v => isFn(v.getDay);
+const isDateRange  = r => isDate(r[0]) && isDate(r[1]);
+const getDateRange = r => (new Date(r[0])-new Date(r[1]))/864e5|0;
+const fillRange = (num1, num2, steps = 1) => Array(Math.abs(num1-num2/steps)+1).fill(num1).map((v,i)=>v+(i*steps)*(num1>num2?-1:1));
+// example usage
+const myRange = [ new Date('2021-01-01'), new Date('2021-01-31') ];
+const dateRange = Math.abs(getDateRange(myRange));
+//console.log('dateRange', dateRange);
+//console.log('fillRange(0,100)', fillRange(0,100,5));
+//console.log('......');
+
+// Not tested/used yet:
+
+// interpolate dates, from https://github.com/d3/d3-interpolate/blob/main/src/date.js
+const interpolateDate = (a, b) => {
+  const d = new Date;
+  return a = +a,
+         b = +b,
+         (t) => d.setTime(a*(1-t)+b*t),
+         d;
+}
+
+// interpolate string stuff.. use with fillRange()
+const numbers = "1st Jan 2001".match(/[0-9]*/g);        //   returns ["1", "", "", "", "", "", "", "", "2001", ""]
+const chars = "1st Jan 2001".match(/[A-Za-z ,\.]*/g)    //   returns ["", "st Jan ", "", "", "", "", ""]
+numbers.map((n, i) => n.length>0 ? `${n}${chars[i+1]||''}` : ''); // returns ["1st Jan ", "", "", "", "", "", "", "", "2001", ""]
+
+
+
+// Data stuff:
+//
+// Functions for working with Objects:
+//
+// Given the object `{ name: "Bob" }`, returns an object like  `{ key: "name", value: "Bob" }`
+const objToKeyValuePairs = obj => Object.keys(obj).map((key) => ({ key, value: obj[key] }));
+//
+//
+// Functions for working with Arrays of Objects:
+//
+// Converts array of object in array of objects containing key/value pairs
+const toKeyValuePairs = array => array.map(obj => objToKeyValuePairs(obj));
+// Given an array of objects, returns an object "keyed" by the given `prop` value
+const toKeyedObject = (array, key, obj = {}) => { array.forEach(item => obj[item[key]] = item); return obj; };
+// Sort an array of objects by the given object `prop` - returns an array,
+// - if asc=true,  the object with the _lowest_ `prop` value comes first
+// - if asc=false, the object with the _highest_ `prop` value comes first
+const sortByKey = (array, prop, order = 'asc') => [...array].sort((a, b) => order === 'asc' ? a[prop]-b[prop] : b[prop]-a[prop]);
+const sortByKeyAsc = (array, prop) => sortByKey(array, prop, 'asc');
+const sortByKeyDesc = (array, prop) => sortByKey(array, prop, 'desc');
+// Get the combined total value of the given object property, in an array of objects,
+// note that each object in the array must contain the given property (`prop`)
+const getSumTotal = (array, prop) => array.reduce((prev, cur) => prev + cur[prop], 0);
+// Get the min/max value of the given `prop` from objects in the given `array` of objects
+const getMinOrMaxValue = (array, prop, which) => Math[which](...array.map(obj => obj[prop]));
+// Get the min value of the given `prop` from objects in the given `array` of objects
+const getMinValue = (array, prop) => getMinOrMaxValue(array, prop, 'min');
+// Get the max value of the given `prop` from objects in the given `array` of objects
+const getMaxValue = (array, prop) => getMinOrMaxValue(array, prop, 'max');
+// Get the object from `array` that has the lowest or highest value for `prop`
+const getObjectWithMinOrMaxValue = (array, prop, which) => array.reduce((max, obj) => which === 'min' ? max[prop]<obj[prop]?max:obj : max[prop]>obj[prop]?max:obj);
+// Get the object from `array` that has the lowest value for `prop`
+const getObjectWithMinValue = (array, prop) => getObjectWithMinOrMaxValue(array, prop, 'min');
+// Get the object from `array` that has the highest value for `prop`
+const getObjectWithMaxValue = (array, prop) => getObjectWithMinOrMaxValue(array, prop, 'max');
+
+
+// =============================================================================
+
+
+
   let frame = 1; // frame count
-  const colors = [ 'rgba(255,0,0, 0.5)', 'rgba(0,0,255, 0.5)' ];
+  const colors = [ 'red', 'lightblue', 'lightgreen', 'orange', 'pink', 'limegreen', 'magenta', 'grey', 'cyan' ];
 
   // Enable our Chart addon, it'll create an extended 2dContext,
   // with a chainable API, and these extra methods:
@@ -28,84 +103,123 @@
   //
   // Inside `.each()`, you get these drawing methods:
   //
-  //    data.circle(), data.rect(), data.line()
+  //    data.circle(), data.bar(), data.line(), data.pie()
   //
   Component.Ctx = Chart;
 
   // define a new component
-  const myChart = new Component({ x: 280, y: 100 });
+  const myChart = new Component({ sizeX: 640, sizeY: 520 });
 
   // define the "view", that draws to the components canvas
   myChart.view = (props, ctx) => {
 
     if (frame === 1) {
       // set the canvas size (w, h, aspectRatio)
-      ctx.size(640,480)           // set width and height, ignore aspect ratio
+      ctx.size(props.sizeX, props.sizeY)  // set width and height, ignore aspect ratio
       //ctx.size(640, 480, null)   // same as above
       //ctx.size(null, 480, 4/3)   // set as 4:3,  grow till height = 4.0
       //ctx.size(null, 480, 16/9)  // set as 16:9, grow till height = 480
       //ctx.size(640, null, 3/4)   // set as 4:3, crop till width = 640
       //ctx.size(640, null, 9/16)  // set as 16:9, crop till width = 640
       //console.clear();
+      frame++;
+      return;
     }
 
+    ctx.clear()
 
-      ctx.beginPath()
 
-      .data({
-        'USA': [{},
-          { year: 2000, medals: 25 },
-          { year: 2001, medals: 15 },
-          { year: 2002, medals: 21 },
-          { year: 2003, medals: 42 },
-          { year: 2004, medals: 47 },
-          { year: 2005, medals: 21 },
-          { year: 2006, medals: 24 },
-        ],
-        'China': [{},
-          { year: 2000, medals: 10 },
-          { year: 2001, medals: 10 },
-          { year: 2002, medals: 25 },
-          { year: 2003, medals: 40 },
-          { year: 2004, medals: 32 },
-          { year: 2005, medals: 12 },
-          { year: 2006, medals: 21 },
-        ]
-      })
-      .margin(50,60,120,40)  // top, bottom, left, right
-      .xAxis([1999,2007], 1, -1.5, 'Year', true, true)  // range, scale, tickSize (%), labelText, labelAlignCenter, labelAlignBelow
-      .yAxis([0,50],      5, -1.5, 'Gold Medals', true) // range, scale, tickSize (%), labelText, labelAlignLeft
-      .each((country, key, i) => {
-        // Now we can work with our "decorated" chart data, ${country}.
-        // Use your top-level data here - to draw a legend, for example..
+    // Pass in your data, an array of objects for simple bar charts, or
+    // (more useful for grouped bar charts & line charts) an object of arrays:
+    .data({
+      'USA':
+      [ {},
+        { medals: 19 },
+        { medals: 30 },
+        { medals: 23 },
+        { medals: 25 },
+        { medals: 12 },
+        { medals: 16 },
+        { medals: 23 },
+      ],
+      'UK':
+      [ {},
+        { medals: 10 },
+        { medals: 9  },
+        { medals: 18 },
+        { medals: 18 },
+        { medals: 15 },
+        { medals: 21 },
+        { medals: 24 },
+      ]
+    })
 
-        // Now lets go over each bit of data for this country
-        country.forEach(data => {
-          if (!data.medals && data.medals !== 0) return;
-          // Note, ${data} has .bar(), .rect(), and .line() methods added,
-          // which try to draw "ready-made" shapes, in the right place.
-          //
-          // You should only define the attrs you want "joined" to your
-          // data - and don't override any others.
-          data.bar({
-            height: data.medals, // (swap xAxis and yAxis above, then use "width")
-            fill: colors[i]
-          });
-          data.circle({
-            cy: data.medals,    // (swap xAxis and yAxis above, then use "cx")
-            cr: 5,
-            fill: colors[i]
-          });
-          data.line({
-            py: data.medals,    // (swap xAxis and yAxis above, then use "py")
-            stroke: colors[i],
-            lineWidth: 3,
-          });
+    .margin(40,80,130,80)  // top, bottom, left, right
+
+    .xAxis([1999,2007],  1, 0, -4, "Years", true, true, []) // range, scale, yPos(%), tickSize(%), name, nameBelow, tickLabelsCentered, tickLabels
+    .yAxis([0,     50],  5, 0, -2, "Gold Medals", true, []) // range, scale, xPos(%), tickSize(%), name, namelLeft, tickLabels
+
+    .drawEach((country, name, i) => {
+      // Now we can work with some "decorated" chart data, ${data}.
+      // You might wanna use your top-level ${data} here - e.g. to draw a legend
+
+      // Also available, just FYI:
+      //const { x, y, h, w, margin, xRange, yRange, xScale, yScale, xDistance, yDistance } = ctx.dimensions();
+      // Do whatever you like with these params, if anything..
+      //    x/y         = the x/y origins of the chart area, accounting for margins
+      //    w/h         = the x/y end points of the chart area, accounting for margins
+      //    margin      = the space in px outside the chart area, in format { top, bottom, left, right }
+      //    x/yRange    = the min/max data values of the x/y axes
+      //    x/yScale    = the number by which axis values are multiplied
+      //    x/yDistance = the tick distance (in px) along the x and y axes
+
+      // Now lets go over each bit of "decorated" data for this country
+      country.forEach((data, n) => {
+        // You should only define the attrs you want "joined" to your
+        // data - and don't override any others!
+        data.bar({
+          height: data.medals,
+          fill: colors[i],
         });
-
+        data.circle({
+          cy:     data.medals,
+          radius: data.medals/2,
+          fill:   colors[i],
+          start: 0,
+          end: 360,
+          rotate: 0,
+        });
+        data.line({
+          py:        data.medals,
+          stroke:    colors[i],
+          lineWidth: 3,
+        });
       });
+    })
 
-      frame++;
+    // ..or change data and add a pie chart
+    .data([
+      { medals: 5 },
+      { medals: 30 },
+      { medals: 10 },
+      { medals: 100 },
+    ])
+    .drawEach(item => {
+      item.forEach((data, i) => {
+        data.pie({
+          slice:  data.medals, // turns into a % of 360 degrees
+          fill: colors[i],
+          px: 420,
+          py: 100,
+          radius: 60,
+        });
+      });
+    })
+
+
+
+
+    frame++;
   };
 
 

--- a/examples/usage-Chart.html
+++ b/examples/usage-Chart.html
@@ -62,13 +62,11 @@ const objToKeyValuePairs = obj => Object.keys(obj).map((key) => ({ key, value: o
 //
 // Functions for working with Arrays of Objects:
 //
-// Converts array of object in array of objects containing key/value pairs
+// Converts an array of objects into an array of objects containing key/value pairs
 const toKeyValuePairs = array => array.map(obj => objToKeyValuePairs(obj));
 // Given an array of objects, returns an object "keyed" by the given `prop` value
 const toKeyedObject = (array, key, obj = {}) => { array.forEach(item => obj[item[key]] = item); return obj; };
 // Sort an array of objects by the given object `prop` - returns an array,
-// - if asc=true,  the object with the _lowest_ `prop` value comes first
-// - if asc=false, the object with the _highest_ `prop` value comes first
 const sortByKey = (array, prop, order = 'asc') => [...array].sort((a, b) => order === 'asc' ? a[prop]-b[prop] : b[prop]-a[prop]);
 const sortByKeyAsc = (array, prop) => sortByKey(array, prop, 'asc');
 const sortByKeyDesc = (array, prop) => sortByKey(array, prop, 'desc');

--- a/examples/usage-Chart.html
+++ b/examples/usage-Chart.html
@@ -1,0 +1,122 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Component - canvas demo</title>
+  <script src="../dist/component.min.js"></script>
+  <script src="../dist/chart.min.js"></script>
+  <style>
+    .container {
+      border: 1px solid #222;
+      margin: 1em;
+      width: 640px;
+      height: 480px;
+    }
+  </style>
+</head>
+<body>
+
+  <canvas class="container"></canvas>
+
+<script>
+  let frame = 1; // frame count
+  const colors = [ 'red', 'blue' ];
+
+  // Enable our Chart addon, it'll create an extended 2dContext,
+  // with a chainable API, and these extra methods:
+  //
+  //    .data(), .margin(), .xAxis(), .yAxis(), .each(),
+  //
+  // Inside `.each()`, you get these drawing methods:
+  //
+  //    data.circle(), data.rect(), data.line()
+  //
+  Component.Ctx = Chart;
+
+
+  // define a new component
+  const Foo = new Component({ x: 280, y: 100 });
+  // define a "view", that draws to the components canvas
+  Foo.view = (props, ctx) => {
+    if (frame === 1) {
+      context = ctx;
+      // set the canvas size (w, h, aspectRatio)
+      ctx.size(600, 480)           // set width and height, ignore aspect ratio
+      //ctx.size(640, 480, null)   // same as above
+      //ctx.size(null, 480, 4/3)   // set as 4:3,  grow till height = 480
+      //ctx.size(null, 480, 16/9)  // set as 16:9, grow till height = 480
+      //ctx.size(640, null, 3/4)   // set as 4:3, crop till width = 640
+      //ctx.size(640, null, 9/16)  // set as 16:9, crop till width = 640
+      console.clear();
+    }
+
+
+    ctx.clear()  // using `clear(true)` will clear transforms too
+
+      .beginPath()
+      .data({
+        'USA': [{},
+          { year: 2000, medals: 25 },
+          { year: 2001, medals: 15 },
+          { year: 2002, medals: 21 },
+          { year: 2003, medals: 42 },
+          { year: 2004, medals: 47 },
+          { year: 2005, medals: 21 },
+          { year: 2006, medals: 24 },
+        ],
+        'China': [{},
+          { year: 2000, medals: 10 },
+          { year: 2001, medals: 10 },
+          { year: 2002, medals: 25 },
+          { year: 2003, medals: 40 },
+          { year: 2004, medals: 32 },
+          { year: 2005, medals: 12 },
+          { year: 2006, medals: 21 },
+        ]
+      })
+      .margin(40,80,120,60)  // top, bottom, left, right
+      .yAxis([1999,2007], 1, -6, 'Year', true)        // range, scale, tickSize, label
+      .xAxis([0,50],      5, -6, 'Gold Medals', false) // range, scale, tickSize, label, centerLabels
+      .each((country, key, i) => {
+        // here you can draw a legend, or whatever..
+        //
+
+        country.forEach(data => {
+          if (!data.medals && data.medals !== 0) return;
+
+          // here you can draw your data:
+          // define only the attributes you need
+
+          data.bar({
+            //height: data.medals,
+            width: data.medals,
+            fill: colors[i]
+          })
+
+          data.circle({
+            //cy: data.medals,
+            cx: data.medals,
+            cr: 3,
+            fill: colors[i]
+          })
+
+          data.lines({
+            //px: data.medals,
+            py: data.medals,
+            stroke: colors[i]
+          })
+
+          // ..etc
+        });
+
+      })
+
+      frame++;
+  };
+
+
+  // render to a canvas, and attach its context (`ctx`) to our component
+  Foo.render('.container', '2d');
+
+</script>
+</body>
+</html>

--- a/examples/usage-Ctx.html
+++ b/examples/usage-Ctx.html
@@ -17,15 +17,14 @@
 <body>
 
   <canvas class="container"></canvas>
-  <!--
-    <br>
-    <video crossorigin="*" controls></video>
-  -->
+  <br>
+  <video crossorigin="*" controls></video>
 
 <script>
   let context; // will be a reference to Foo.ctx, so we can access it outside the components view
   let frame = 1; // frame count
   const arr = [ 1,2,3,4,5,6,7,8,9,0 ]; // used in a maths helper example later on
+
 
 
   // Enable the enhanced canvas 2dContext API (optional).
@@ -52,31 +51,9 @@
       //ctx.size(640, null, 9/16)  // set as 16:9, crop till width = 640
     }
 
+
     ctx
       .clear()  // using `clear(true)` will clear transforms too
-
-      .beginPath()
-      .data([
-        { year: 1996, gold: 11 },
-        { year: 1997, gold: 15 },
-        { year: 1998, gold: 13 },
-        { year: 1999, gold: 18 },
-        { year: 2000, gold: 18 },
-        { year: 2001, gold: 14 },
-        { year: 2002, gold: 25 },
-        { year: 2003, gold: 42 },
-        { year: 2004, gold: 47 },
-        { year: 2005, gold: 25 },
-        { year: 2006, gold: 24 },
-      ])
-      .margin(50,70,120,100)                 // top, bottom, left, right
-      .xAxis([1996,2006], 1, -6, 'Year')        // range, scale, tickSize, label
-      .yAxis([0,50],      5, -6, 'Gold Medals') // range, scale, tickSize, label
-      // map elem x,y to numbs adhusted for scale/marins/etc
-      //.lines('gold')
-
-
-
 
       // uncomment one of the lines below to try out the "camera":
       // usage: camera(xCenter, yCenter, scale, rotation); // rotation is in degrees
@@ -86,110 +63,110 @@
       //.camera(640, 480, 2, 0)
       //.camera(320, 240, 4-(1+frame/400), 0)
 
-//      .beginPath()
-//      .drawGrid(12)
+      .beginPath()
+      .drawGrid(12)
 
-//      .beginPath()
-//      .drawGridBox(400,280, 200,100, 25, 0.5, '#c00')
+      .beginPath()
+      .drawGridBox(400,280, 200,100, 25, 0.5, '#c00')
 
-//      .beginPath()
-//      .checkerboard(30, 300-frame, 100, 100, 15, '#222', '#efefef')
+      .beginPath()
+      .checkerboard(30, 300-frame, 100, 100, 15, '#222', '#efefef')
 
-//      .beginPath()
-//      .fillStyle('purple')
-//      .polygon([
-//          [10 + props.y, 10],
-//          [200- + props.y / 2,10 + props.y],
-//          [200,200],
-//          [100 + props.y, 220],
-//        ],
-//        [],  // line dash pattern [dash,gap,dash,gap,..]
-//        true // fill or not
-//      )
-//      .fill()
+      .beginPath()
+      .fillStyle('purple')
+      .polygon([
+          [10 + props.y, 10],
+          [200- + props.y / 2,10 + props.y],
+          [200,200],
+          [100 + props.y, 220],
+        ],
+        [],  // line dash pattern [dash,gap,dash,gap,..]
+        true // fill or not
+      )
+      .fill()
 
-//      .beginPath()
-//      .moveTo(0, 0)
-//      .lineWidth(2)
-//      .strokeStyle('blue')
-//      .lineTo(props.x, props.y)
-//      .stroke()
+      .beginPath()
+      .moveTo(0, 0)
+      .lineWidth(2)
+      .strokeStyle('blue')
+      .lineTo(props.x, props.y)
+      .stroke()
 
-//      .beginPath()
-//      .strokeStyle('black')
-//      .rect(props.x / 2, props.y / 2, 50, 50)
-//      .stroke()
+      .beginPath()
+      .strokeStyle('black')
+      .rect(props.x / 2, props.y / 2, 50, 50)
+      .stroke()
 
-//      .beginPath()
-//      .fillStyle('yellow')
-//      .strokeStyle('green')
-//      .fillRoundedRect(10, 70, 50, 75, 10)
-//      .stroke()
+      .beginPath()
+      .fillStyle('yellow')
+      .strokeStyle('green')
+      .fillRoundedRect(10, 70, 50, 75, 10)
+      .stroke()
 
-//      .beginPath()
-//      .strokeStyle('pink')
-//      .lineWidth(4)
-//      .strokeTriangle(220, 60, 50, 45)
+      .beginPath()
+      .strokeStyle('pink')
+      .lineWidth(4)
+      .strokeTriangle(220, 60, 50, 45)
 
-//      .beginPath()
-//      .fillStyle('orange')
-//      .fillCircle(320, 240, 20, 0 + frame)
+      .beginPath()
+      .fillStyle('orange')
+      .fillCircle(320, 240, 20, 0 + frame)
 
-//      .beginPath()
-//      .fillStyle('green')
-//      .fillRing(80, 100, (props.y / 8) + 10, (props.y / 8) + 20, 100)
+      .beginPath()
+      .fillStyle('green')
+      .fillRing(80, 100, (props.y / 8) + 10, (props.y / 8) + 20, 100)
 
-//      .beginPath()
-//      .gradientRect(props.y, props.y, 200, 80,
-//        // fill gradient settings
-//        [
-//          [ 0.0, "red"   ],
-//          [ 0.5, "blue"  ],
-//          [ 1.0, "rgb(0,255,0)" ],
-//        ],
-//        true // horizontal (optional), defaults to true (false is vertical)
-//      )
+      .beginPath()
+      .gradientRect(props.y, props.y, 200, 80,
+        // fill gradient settings
+        [
+          [ 0.0, "red"   ],
+          [ 0.5, "blue"  ],
+          [ 1.0, "rgb(0,255,0)" ],
+        ],
+        true // horizontal (optional), defaults to true (false is vertical)
+      )
 
-//      .beginPath()
-//      .gradientCircle(
-//        (props.y+10)*2, props.y-100,   // position x, y
-//        5, 50,                         // innerRadius, outerRadius
-//        50-props.y/5, 50-props.y/5,    // radius offset (from center of circle) x, y
-//        // fill gradient settings
-//        [
-//          [ 0, "red"   ],
-//          [ 1, "yellow" ],
-//        ],
-//      )
+      .beginPath()
+      .gradientCircle(
+        (props.y+10)*2, props.y-100,   // position x, y
+        5, 50,                         // innerRadius, outerRadius
+        50-props.y/5, 50-props.y/5,    // radius offset (from center of circle) x, y
+        // fill gradient settings
+        [
+          [ 0, "red"   ],
+          [ 1, "yellow" ],
+        ],
+      )
 
-//      .beginPath()
-//      .strokeStyle('gold')
- //     .fillStyle('yellow')
- //     .strokeStar(200, 200, 50, 5, 0)
- //     .fill()
+      .beginPath()
+      .strokeStyle('gold')
+      .fillStyle('yellow')
+      .strokeStar(200, 200, 50, 5, 0)
+      .fill()
 
-//      .drawImg(`<svg xmlns="http://www.w3.org/2000/svg" stroke="#000" stroke-width="1">
-//       <rect x="80" y="60" width="150" height="150" rx="20" fill="#F00"/>
-//       <rect x="100" y="80" width="150" height="150" rx="40" fill="#00F" fill-opacity=".7"/>
-//      </svg>`, 100 + props.y, 200 - props.y / 2, 250, 150) // urlOrElemOrCode, x, y, w, h
+      .drawImg(`<svg xmlns="http://www.w3.org/2000/svg" stroke="#000" stroke-width="1">
+       <rect x="80" y="60" width="150" height="150" rx="20" fill="#F00"/>
+       <rect x="100" y="80" width="150" height="150" rx="40" fill="#00F" fill-opacity=".7"/>
+      </svg>`, 100 + props.y, 200 - props.y / 2, 250, 150) // urlOrElemOrCode, x, y, w, h
 
-//      .drawImg('https://i.imgur.com/yL240c7.png', 100+frame, 300, 150, 150)
+      .drawImg('https://i.imgur.com/yL240c7.png', 100+frame, 300, 150, 150)
 
       // pacman
-//      ctx.circle(320, 360, 50, 0+frame, false) // x, y, radius, degrees, antiClockwise
-//      ctx.fillStyle("yellow");
-//      ctx.fill()
+      ctx.circle(320, 360, 50, 0+frame, false) // x, y, radius, degrees, antiClockwise
+      ctx.fillStyle("yellow");
+      ctx.fill()
 
-//      .strokeStyle('black')
-//      .fillStyle('black')
-//      .lineWidth(1)
+      .strokeStyle('black')
+      .fillStyle('black')
+      .lineWidth(1)
 
       //      x1,  y1, x2, y2, style, size, whichEnd,  headAngle
-//      .arrow(150, 360, 50, 60,     0,   10,        3,     33)
+      .arrow(150, 360, 50, 60,     0,   10,        3,     33)
       //         x1,  y1,  r, start,  end, antiClockwise, style, size,  whichEnd    headAngle
-//      .arcArrow(150, 360, 50,     0,  180,         false,     0,   10,         3,   33)
+      .arcArrow(150, 360, 50,     0,  180,         false,     0,   10,         3,   33)
 
-//      .spiral(500, 100,  80, 300,  frame, 2, '#c44')
+      .spiral(500, 100,  80, 300,  frame, 2, '#c44')
 
       // uncomment one of the lines below to try the "chroma key" filtering
 
@@ -212,28 +189,28 @@
 
   // ..after the first frame renders (takes about 16 milliseconds)
   // we can access `ctx` outside this components view, as `context`
-//  setTimeout(() => {
-//    context.video.record(60); // start recording a video @60fps
-//  }, 20);
+  setTimeout(() => {
+    context.video.record(60); // start recording a video @60fps
+  }, 20);
 
 
   // move stuff around a bit in an animated loop
-  //const loop = setInterval(() => {
-  //  Foo.setState({
-  //    x: 300,
-  //    y: Foo.state.y += 1
-  //  });
-  //}, 1000 / 60);
+  const loop = setInterval(() => {
+    Foo.setState({
+      x: 300,
+      y: Foo.state.y += 1
+    });
+  }, 1000 / 60);
 
 
   // after 5 seconds, stop loop, stop recording the canvas to video,
   // and offer to download it
-  //setTimeout(() => {
-    //clearInterval(loop);
-//    context.video.stop();
-//    context.video.toElement(el => document.querySelector('video').src = el.src);
+  setTimeout(() => {
+    clearInterval(loop);
+    context.video.stop();
+    context.video.toElement(el => document.querySelector('video').src = el.src);
     //context.video.saveAs('canvas-as-video.webm');
-  //}, 5500);
+  }, 5500);
 
 </script>
 </body>

--- a/examples/usage-Ctx.html
+++ b/examples/usage-Ctx.html
@@ -17,8 +17,10 @@
 <body>
 
   <canvas class="container"></canvas>
-  <br>
-  <video crossorigin="*" controls></video>
+  <!--
+    <br>
+    <video crossorigin="*" controls></video>
+  -->
 
 <script>
   let context; // will be a reference to Foo.ctx, so we can access it outside the components view
@@ -52,7 +54,28 @@
 
     ctx
       .clear()  // using `clear(true)` will clear transforms too
+
       .beginPath()
+      .data([
+        { year: 1996, gold: 11 },
+        { year: 1997, gold: 15 },
+        { year: 1998, gold: 13 },
+        { year: 1999, gold: 18 },
+        { year: 2000, gold: 18 },
+        { year: 2001, gold: 14 },
+        { year: 2002, gold: 25 },
+        { year: 2003, gold: 42 },
+        { year: 2004, gold: 47 },
+        { year: 2005, gold: 25 },
+        { year: 2006, gold: 24 },
+      ])
+      //.margin(50,70,120,100)                 // top, bottom, left, right
+      .xAxis([1996,2006], 1, -5, 'Year')        // range, scale, tickSize, label
+      .yAxis([0,50],      5, -5, 'Gold Medals') // range, scale, tickSize, label
+      // map elem x,y to numbs adhusted for scale/marins/etc
+
+
+
 
       // uncomment one of the lines below to try out the "camera":
       // usage: camera(xCenter, yCenter, scale, rotation); // rotation is in degrees
@@ -62,110 +85,110 @@
       //.camera(640, 480, 2, 0)
       //.camera(320, 240, 4-(1+frame/400), 0)
 
-      .beginPath()
-      .drawGrid(12)
+//      .beginPath()
+//      .drawGrid(12)
 
-      .beginPath()
-      .drawGridBox(400,280, 200,100, 25, 0.5, '#c00')
+//      .beginPath()
+//      .drawGridBox(400,280, 200,100, 25, 0.5, '#c00')
 
-      .beginPath()
-      .checkerboard(30, 300-frame, 100, 100, 15, '#222', '#efefef')
+//      .beginPath()
+//      .checkerboard(30, 300-frame, 100, 100, 15, '#222', '#efefef')
 
-      .beginPath()
-      .fillStyle('purple')
-      .polygon([
-          [10 + props.y, 10],
-          [200- + props.y / 2,10 + props.y],
-          [200,200],
-          [100 + props.y, 220],
-        ],
-        [],  // line dash pattern [dash,gap,dash,gap,..]
-        true // fill or not
-      )
-      .fill()
+//      .beginPath()
+//      .fillStyle('purple')
+//      .polygon([
+//          [10 + props.y, 10],
+//          [200- + props.y / 2,10 + props.y],
+//          [200,200],
+//          [100 + props.y, 220],
+//        ],
+//        [],  // line dash pattern [dash,gap,dash,gap,..]
+//        true // fill or not
+//      )
+//      .fill()
 
-      .beginPath()
-      .moveTo(0, 0)
-      .lineWidth(2)
-      .strokeStyle('blue')
-      .lineTo(props.x, props.y)
-      .stroke()
+//      .beginPath()
+//      .moveTo(0, 0)
+//      .lineWidth(2)
+//      .strokeStyle('blue')
+//      .lineTo(props.x, props.y)
+//      .stroke()
 
-      .beginPath()
-      .strokeStyle('black')
-      .rect(props.x / 2, props.y / 2, 50, 50)
-      .stroke()
+//      .beginPath()
+//      .strokeStyle('black')
+//      .rect(props.x / 2, props.y / 2, 50, 50)
+//      .stroke()
 
-      .beginPath()
-      .fillStyle('yellow')
-      .strokeStyle('green')
-      .fillRoundedRect(10, 70, 50, 75, 10)
-      .stroke()
+//      .beginPath()
+//      .fillStyle('yellow')
+//      .strokeStyle('green')
+//      .fillRoundedRect(10, 70, 50, 75, 10)
+//      .stroke()
 
-      .beginPath()
-      .strokeStyle('pink')
-      .lineWidth(4)
-      .strokeTriangle(220, 60, 50, 45)
+//      .beginPath()
+//      .strokeStyle('pink')
+//      .lineWidth(4)
+//      .strokeTriangle(220, 60, 50, 45)
 
-      .beginPath()
-      .fillStyle('orange')
-      .fillCircle(320, 240, 20, 0 + frame)
+//      .beginPath()
+//      .fillStyle('orange')
+//      .fillCircle(320, 240, 20, 0 + frame)
 
-      .beginPath()
-      .fillStyle('green')
-      .fillRing(80, 100, (props.y / 8) + 10, (props.y / 8) + 20, 100)
+//      .beginPath()
+//      .fillStyle('green')
+//      .fillRing(80, 100, (props.y / 8) + 10, (props.y / 8) + 20, 100)
 
-      .beginPath()
-      .gradientRect(props.y, props.y, 200, 80,
-        // fill gradient settings
-        [
-          [ 0.0, "red"   ],
-          [ 0.5, "blue"  ],
-          [ 1.0, "rgb(0,255,0)" ],
-        ],
-        true // horizontal (optional), defaults to true (false is vertical)
-      )
+//      .beginPath()
+//      .gradientRect(props.y, props.y, 200, 80,
+//        // fill gradient settings
+//        [
+//          [ 0.0, "red"   ],
+//          [ 0.5, "blue"  ],
+//          [ 1.0, "rgb(0,255,0)" ],
+//        ],
+//        true // horizontal (optional), defaults to true (false is vertical)
+//      )
 
-      .beginPath()
-      .gradientCircle(
-        (props.y+10)*2, props.y-100,   // position x, y
-        5, 50,                         // innerRadius, outerRadius
-        50-props.y/5, 50-props.y/5,    // radius offset (from center of circle) x, y
-        // fill gradient settings
-        [
-          [ 0, "red"   ],
-          [ 1, "yellow" ],
-        ],
-      )
+//      .beginPath()
+//      .gradientCircle(
+//        (props.y+10)*2, props.y-100,   // position x, y
+//        5, 50,                         // innerRadius, outerRadius
+//        50-props.y/5, 50-props.y/5,    // radius offset (from center of circle) x, y
+//        // fill gradient settings
+//        [
+//          [ 0, "red"   ],
+//          [ 1, "yellow" ],
+//        ],
+//      )
 
-      .beginPath()
-      .strokeStyle('gold')
-      .fillStyle('yellow')
-      .strokeStar(200, 200, 50, 5, 0)
-      .fill()
+//      .beginPath()
+//      .strokeStyle('gold')
+ //     .fillStyle('yellow')
+ //     .strokeStar(200, 200, 50, 5, 0)
+ //     .fill()
 
-      .drawImg(`<svg xmlns="http://www.w3.org/2000/svg" stroke="#000" stroke-width="1">
-       <rect x="80" y="60" width="150" height="150" rx="20" fill="#F00"/>
-       <rect x="100" y="80" width="150" height="150" rx="40" fill="#00F" fill-opacity=".7"/>
-      </svg>`, 100 + props.y, 200 - props.y / 2, 250, 150) // urlOrElemOrCode, x, y, w, h
+//      .drawImg(`<svg xmlns="http://www.w3.org/2000/svg" stroke="#000" stroke-width="1">
+//       <rect x="80" y="60" width="150" height="150" rx="20" fill="#F00"/>
+//       <rect x="100" y="80" width="150" height="150" rx="40" fill="#00F" fill-opacity=".7"/>
+//      </svg>`, 100 + props.y, 200 - props.y / 2, 250, 150) // urlOrElemOrCode, x, y, w, h
 
-      .drawImg('https://i.imgur.com/yL240c7.png', 100+frame, 300, 150, 150)
+//      .drawImg('https://i.imgur.com/yL240c7.png', 100+frame, 300, 150, 150)
 
       // pacman
-      ctx.circle(320, 360, 50, 0+frame, false) // x, y, radius, degrees, antiClockwise
-      ctx.fillStyle("yellow");
-      ctx.fill()
+//      ctx.circle(320, 360, 50, 0+frame, false) // x, y, radius, degrees, antiClockwise
+//      ctx.fillStyle("yellow");
+//      ctx.fill()
 
-      .strokeStyle('black')
-      .fillStyle('black')
-      .lineWidth(1)
+//      .strokeStyle('black')
+//      .fillStyle('black')
+//      .lineWidth(1)
 
       //      x1,  y1, x2, y2, style, size, whichEnd,  headAngle
-      .arrow(150, 360, 50, 60,     0,   10,        3,     33)
+//      .arrow(150, 360, 50, 60,     0,   10,        3,     33)
       //         x1,  y1,  r, start,  end, antiClockwise, style, size,  whichEnd    headAngle
-      .arcArrow(150, 360, 50,     0,  180,         false,     0,   10,         3,   33)
+//      .arcArrow(150, 360, 50,     0,  180,         false,     0,   10,         3,   33)
 
-      .spiral(500, 100,  80, 300,  frame, 2, '#c44')
+//      .spiral(500, 100,  80, 300,  frame, 2, '#c44')
 
       // uncomment one of the lines below to try the "chroma key" filtering
 
@@ -188,29 +211,88 @@
 
   // ..after the first frame renders (takes about 16 milliseconds)
   // we can access `ctx` outside this components view, as `context`
-  setTimeout(() => {
-    context.video.record(60); // start recording a video @60fps
-  }, 20);
+//  setTimeout(() => {
+//    context.video.record(60); // start recording a video @60fps
+//  }, 20);
 
 
   // move stuff around a bit in an animated loop
-  const loop = setInterval(() => {
-    Foo.setState({
-      x: 300,
-      y: Foo.state.y += 1
-    });
-  }, 1000 / 60);
+  //const loop = setInterval(() => {
+  //  Foo.setState({
+  //    x: 300,
+  //    y: Foo.state.y += 1
+  //  });
+  //}, 1000 / 60);
 
 
   // after 5 seconds, stop loop, stop recording the canvas to video,
   // and offer to download it
-  setTimeout(() => {
-    clearInterval(loop);
-    context.video.stop();
-    context.video.toElement(el => document.querySelector('video').src = el.src);
+  //setTimeout(() => {
+    //clearInterval(loop);
+//    context.video.stop();
+//    context.video.toElement(el => document.querySelector('video').src = el.src);
     //context.video.saveAs('canvas-as-video.webm');
-  }, 5500);
+  //}, 5500);
 
 </script>
 </body>
 </html>
+
+<!--
+
+
+    ctx
+      chart(someArrayOfObjects)
+        .position(0, 0)
+        .title('How many hours did you work each week this year?')
+        .width(800)
+        .height(600)
+        .margins([24, 24, 24, 24])
+        .xAxis({
+          title: { text: 'Days', position: 'below' },
+          range: [0, 365],
+          labels: ['Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat', 'Sun'],
+          ticks: {
+            length: 4,
+            color: '#444',
+            position: 'above',
+          },
+        })
+        .yAxis({
+          title: { text: 'Hours', position: 'left' },
+          range: [0, 24],
+          ticks: {
+            length: 4,
+            color: '#444',
+            position: 'right',
+          },
+        })
+        .draw(d => {
+          // this = chart object
+          // Here are the properties and methods available inside draw()
+          this.width
+          this.height
+          this.margin
+          this.xAxis
+          this.yAxis
+          //
+
+          // background grid
+          this.grid(cellSize, lineColor, lineWidth)
+          // scatter plot
+          this.circle(x,y)     // radius based on d.value
+          // bar charts
+          this.rect(x,y)       // h based on d.value, w based on number of bars
+          // pie charts
+          this.pieSlice(x,y)   // start + end rotations based on d.value and data index
+          // line charts
+          this.line(x,y)       //
+
+
+        })
+
+
+
+
+
+-->

--- a/examples/usage-Ctx.html
+++ b/examples/usage-Ctx.html
@@ -69,10 +69,11 @@
         { year: 2005, gold: 25 },
         { year: 2006, gold: 24 },
       ])
-      //.margin(50,70,120,100)                 // top, bottom, left, right
-      .xAxis([1996,2006], 1, -5, 'Year')        // range, scale, tickSize, label
-      .yAxis([0,50],      5, -5, 'Gold Medals') // range, scale, tickSize, label
+      .margin(50,70,120,100)                 // top, bottom, left, right
+      .xAxis([1996,2006], 1, -6, 'Year')        // range, scale, tickSize, label
+      .yAxis([0,50],      5, -6, 'Gold Medals') // range, scale, tickSize, label
       // map elem x,y to numbs adhusted for scale/marins/etc
+      //.lines('gold')
 
 
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -123,6 +123,16 @@ export default [
     plugins: [resolve({ modulesOnly: true }), commonjs(), terser(), sourcemaps()]
   },
   {
+    input: "src/chart.js",
+    output: {
+      file: "dist/chart.min.js",
+      sourcemap: true,
+      name: "Chart",
+      format: "umd"
+    },
+    plugins: [resolve({ modulesOnly: true }), commonjs(), terser(), sourcemaps()]
+  },
+  {
     input: "src/ctx.js",
     output: {
       file: "dist/ctx.min.js",

--- a/src/chart.js
+++ b/src/chart.js
@@ -3,34 +3,12 @@
  *
  */
 
-  // @TODO - fixes and improvements
-  //
-  // - refactor: dont cache lines, draw them in the same func as the other shapes
-  // - fix: use `clip` to remove inner circle of doughnuts/arcs, to it doesn't remove bits of the other shapes
-  //    - fix: once `clip` fix is working, allow setting stroke lines on pie/doughnut/arc arc shapes
-
-  // @TODO - more drawing methods:
-  //
-  // - candlesticks:  .candle({ open, close, low, high, green, red, whichAxis })`
-
-  // @TODO - a radial axis, that draws a circle, ticks extending inwards/outwards from the outside edge
-  //
-  // - see https://github.com/vasturiano/d3-radial-axis
-  // - x axis rotates around the circle
-  // - y axis reaches from centre to each tick on x axis
-  // - avail axes are:
-  //  - degrees around edge (x axis)
-  //  - distance from centre (y axis)
-  //  - number of rotations
-  //  - direction of rotation
-
-  // @TODO - more chart types
-  //
-  // - spider charts           https://yangdanny97.github.io/blog/2019/03/01/D3-Spider-Chart
-  // - parallell coords plot:  multiple Y axes, implicit/invisible X axis: https://datavizcatalogue.com/methods/parallel_coordinates.html
-
-
-
+// @TODO Fixes and improvements:
+//
+// - fix mis-aligned stacked bars (see magic 1.2 number in setting of `barWidth`)
+//
+//
+//
 
 
 const ctxMethods = 'arc arcTo beginPath bezierCurveTo clearRect clip closePath createImageData createLinearGradient createRadialGradient createPattern drawFocusRing drawImage fill fillRect fillText getImageData isPointInPath lineTo measureText moveTo putImageData quadraticCurveTo rect restore rotate save scale setTransform stroke strokeRect strokeText transform translate'.split(' ');
@@ -86,14 +64,6 @@ const isFn = v => typeof v ==='function',
       getSumTotal = (array, prop) => array.filter(item => item[prop]).reduce((prev, cur) => prev + cur[prop], 0);
 
 
-// clears a circular area on canvas, like clearRect, for circles
-//const clearCircle = (ctx, x, y, r) => {
-//    for(let i = 0; i < Math.round( Math.PI * r ); i++ ) {
-//        let angle = ( i / Math.round( Math.PI * r )) * 360;
-//        ctx.clearRect( x , y , Math.sin( angle * ( Math.PI / 180 )) * r , Math.cos( angle * ( Math.PI / 180 )) * r );
-//    }
-//}
-
 // returns the scaled value of the given position in the given range
 //const scale = ({ range, scale, position }) => {
 //  const [min, max] = range;
@@ -112,12 +82,14 @@ const setStyle = (ctx, obj) => {
 
 // returns the dimensions and sizings used by the chart/graph
 function getDimensions(ctx) {
-  const w = ctx.canvas.width-ctx.margin.right-ctx.margin.left;
-  const h = ctx.canvas.height-ctx.margin.top-ctx.margin.bottom;
-  const x = 0+ctx.margin.left;
-  const y = ctx.margin.top+h;
+  const c = ctx.canvas,
+        m = ctx.margin,
+        w = c.width - m.right - m.left,
+        h = c.height - m.top - m.bottom,
+        x = m.left,
+        y = m.top + h;
   const { xRange, yRange, xScale, yScale, xLabels, yLabels, xDistance, yDistance } = ctx._d;
-  return { x, y, w, h, margin: ctx.margin, xRange, yRange, xScale, yScale, xLabels, yLabels, xDistance, yDistance };
+  return { x, y, w, h, margin: m, xRange, yRange, xScale, yScale, xLabels, yLabels, xDistance, yDistance };
 }
 
 // draws the main line of the axis, used by xAxis and yAxis
@@ -213,13 +185,14 @@ const extraMethods = {
     this.w = w ? w : h * a;
     this.h = h ? h : w * a;
     // respect device pixel ratio
-    const c = this.canvas;
+    const c = this.canvas,
+          s = c.style;
     c.width = this.w * PIXEL_RATIO;
     c.height = this.h * PIXEL_RATIO;
     // update the CSS too
-    c.style.width = this.w + 'px';
-    c.style.height = this.h + 'px';
-    c.style.objectFit = a ? 'contain' : null;
+    s.width = this.w + 'px';
+    s.height = this.h + 'px';
+    s.objectFit = a ? 'contain' : null;
     // adjust scale for pixel ratio
     if (this.contextType === '2d' && PIXEL_RATIO !== 1) {
       this.scale(PIXEL_RATIO, PIXEL_RATIO);
@@ -492,7 +465,7 @@ const extraMethods = {
             this.save();
             setStyle(this, style);
             this.moveTo(px, getY(high, n));
-            this.lineTo(px, getY(low, n)-1);
+            this.lineTo(px, getY(low, n)-1); // -1 just to make a little nicer visual gap with the axis..
             this.stroke();
             this.restore();
           }

--- a/src/chart.js
+++ b/src/chart.js
@@ -52,11 +52,13 @@ const PIXEL_RATIO = (function () {
 
 // helper funcs
 
-// used by xAxis and yAxis, returns the scaled value of the given position in the given range
-const scale = ({ range, scale, position }) => {
-  const [min, max] = range;
-  return min + (position - min) * scale;
-};
+//const isFn = v => typeof v ==='function';
+
+// returns the scaled value of the given position in the given range
+//const scale = ({ range, scale, position }) => {
+//  const [min, max] = range;
+//  return min + (position - min) * scale;
+//};
 
 
 // returns the dimensions of the chart/graph axes, taking margins into account
@@ -192,41 +194,35 @@ const extraMethods = {
           }
 
           const drawCircle = ({ cx, cy, cr, fill }) => {
-            const setCx = (cx||cx===0),
-                  setCy = (cy||cy===0),
-                  circleX = (cx) => {
-                    return xFlipped
-                      ? setCx
-                        // if user passed in cx
-                        ? (x+w)-((xDistance*cx)-(xDistance*minXRange))
-                        // if user didn't pass in cx
-                        : x+w-(xDistance*n)*xScale
+            const useCx = (cx||cx===0),
+                  useCy = (cy||cy===0);
 
-                      : setCx
-                        ? x+(xDistance*cx)-(xDistance*minXRange)
-                        : x+(xDistance*n)*xScale
-                  },
-                  circleY = cy => {
-                    return yFlipped
-                      ? setCy
-                        // if user passed in cy
-                        ? ((y-h)+(yDistance*cy))-(yDistance*minYRange)
-                        // if user didn't pass in cy
-                        : y-h+(yDistance*n)*yScale
-
-                      : setCy
-                        // if user passed in cy
-                        ? y-(yDistance*cy)+(yDistance*minYRange)
-                        // if user didn't pass in cy
-                        : y-(yDistance*n)*yScale
-                  };
+            if (!useCx && !useCy) return;
 
             this.beginPath();
             this.arc(
               // x
-              circleX(cx),
+              xFlipped
+                ? useCx
+                  // if user passed in cx
+                  ? (x+w)-((xDistance*cx)-(xDistance*minXRange))
+                  // if user didn't pass in cx
+                  : x+w-(xDistance*n)*xScale
+                : useCx
+                  ? x+(xDistance*cx)-(xDistance*minXRange)
+                  : x+(xDistance*n)*xScale,
               // y
-              circleY(cy),
+              yFlipped
+                ? useCy
+                  // if user passed in cy
+                  ? ((y-h)+(yDistance*cy))-(yDistance*minYRange)
+                  // if user didn't pass in cy
+                  : y-h+(yDistance*n)*yScale
+                : useCy
+                  // if user passed in cy
+                  ? y-(yDistance*cy)+(yDistance*minYRange)
+                  // if user didn't pass in cy
+                  : y-(yDistance*n)*yScale,
               // radius
               cr||5,
               // start angle, end angle (in radians)
@@ -244,12 +240,14 @@ const extraMethods = {
             const useHeight = (height||height===0),
                   useWidth = (width||width===0);
 
+            if (!useWidth && !useHeight) return;
+
             this.beginPath();
             this.rect(
               // x
               xFlipped
                 ? useHeight
-                  ? this.margin.left+w-(xDistance*n)-xDistance/4
+                  ? x+w-(xDistance*n)-xDistance/4
                   : x+w
                 : useHeight
                   ? x+(xDistance*n)-xDistance/4
@@ -301,31 +299,34 @@ const extraMethods = {
         if (cachedLines.length < 1) return;
         this.save();
         cachedLines.forEach(key => {
-          const { px, py, lineWidth, stroke } = lineCache[key][0];
-          if (lineWidth) this.lineWidth = lineWidth;
-          if (stroke) this.strokeStyle = stroke;
-
           this.beginPath();
           lineCache[key].forEach((line, i) => {
-            const usePx = (line.px||line.px===0),
-                  usePy = (line.py||line.py===0);
+            const { px, py, lineWidth, stroke } = lineCache[key][i],
+                  usePx = (px||px===0),
+                  usePy = (py||py===0);
+
+            if (!usePx && !usePy) return;
+            if (lineWidth) this.lineWidth = lineWidth;
+            if (stroke) this.strokeStyle = stroke;
+
             if (i === 0){
               this.moveTo(
                 xFlipped
-                  ? usePx ? x+w-xDistance*px+(xDistance*minXRange) : (x+w)-((xDistance*1)*xScale)
-                  : usePx ? x+xDistance*px-(xDistance*minXRange) : x+((xDistance*1)*xScale),
+                  ? usePx ? x+w-xDistance*px+(xDistance*minXRange) : (x+w)-((xDistance*(i))*xScale)
+                  : usePx ? x+xDistance*px-(xDistance*minXRange) : x+((xDistance*(i))*xScale),
                 yFlipped
-                  ? usePy ? (y-h)+(yDistance*py)-(yDistance*minYRange) : (y-h)+((yDistance*1)*yScale)
-                  : usePy ? y-yDistance*py+(yDistance*minYRange) : y-((yDistance*1)*yScale)
+                  ? usePy ? (y-h)+(yDistance*py)-(yDistance*minYRange) : (y-h)+((yDistance*(i))*yScale)
+                  : usePy ? y-yDistance*py+(yDistance*minYRange) : y-((yDistance*(i))*yScale)
               );
             }
+            console.log('drawing line', i);
             this.lineTo(
               xFlipped
-                ? usePx ? x+w-xDistance*line.px+(xDistance*minXRange) : (x+w)-((xDistance*(i+1))*xScale)
-                : usePx ? x+xDistance*line.px-(xDistance*minXRange) : x+((xDistance*(i+1))*xScale),
+                ? usePx ? x+w-xDistance*px+(xDistance*minXRange) : (x+w)-((xDistance*(i))*xScale)
+                : usePx ? x+xDistance*px-(xDistance*minXRange) : x+((xDistance*(i))*xScale),
               yFlipped
-                ? usePy ? (y-h)+(yDistance*line.py)-(yDistance*minYRange) : (y-h)+((yDistance*(i+1))*yScale)
-                : usePy ? y-yDistance*line.py+(yDistance*minYRange) : y-((yDistance*(i+1))*yScale),
+                ? usePy ? (y-h)+(yDistance*py)-(yDistance*minYRange) : (y-h)+((yDistance*(i))*yScale)
+                : usePy ? y-yDistance*py+(yDistance*minYRange) : y-((yDistance*(i))*yScale),
             );
             this.stroke();
           });

--- a/src/chart.js
+++ b/src/chart.js
@@ -12,12 +12,6 @@
   // @TODO - more drawing methods:
   //
   // - candlesticks:  .candle({ open, close, low, high, green, red, whichAxis })`
-  // - draw svg:      .svg({ x, y, w, h , data })  ..where `data` is { '.a-selector': { 'fill':  data.foo }
-
-  // @TODO - more chart types
-  //
-  // - spider charts           https://yangdanny97.github.io/blog/2019/03/01/D3-Spider-Chart
-  // - parallell coords plot:  multiple Y axes, implicit/invisible X axis: https://datavizcatalogue.com/methods/parallel_coordinates.html
 
   // @TODO - a radial axis, that draws a circle, ticks extending inwards/outwards from the outside edge
   //
@@ -29,6 +23,13 @@
   //  - distance from centre (y axis)
   //  - number of rotations
   //  - direction of rotation
+
+  // @TODO - more chart types
+  //
+  // - spider charts           https://yangdanny97.github.io/blog/2019/03/01/D3-Spider-Chart
+  // - parallell coords plot:  multiple Y axes, implicit/invisible X axis: https://datavizcatalogue.com/methods/parallel_coordinates.html
+
+
 
 
 

--- a/src/chart.js
+++ b/src/chart.js
@@ -7,6 +7,40 @@
  *
  */
 
+  // @TODO - fixes
+  //
+  // - sharper/crisper lines:  translate canvas by 0.5px, and round everything to 1px
+  // -
+  //
+  //
+
+
+  // @TODO - add more drawing methods:
+  //
+  // - rounded lines                         https://stackoverflow.com/a/40978275/5479837
+  // - spider charts                         https://yangdanny97.github.io/blog/2019/03/01/D3-Spider-Chart
+  // - candlesticks:                         .candle({ open, close, low, high, green, red, whichAxis })
+  // - draw svg or fn(ctx, x, y):            .svg({ x, y, w, h , data })  where `data` is { '.a-selector': { 'fill':  data.foo }
+  // - parallell coords plot:                ...multiple Y axes, implicit/invisible X axis: https://datavizcatalogue.com/methods/parallel_coordinates.html
+
+  //
+  // @TODO - a radial axis, that draws a circle, ticks extending inwards/outwards from the outside edge
+  //
+  // - see https://github.com/vasturiano/d3-radial-axis
+  // - rotate around and draw tick for each axis point, accounting for scale
+  // - spread range over 360, so always draw a full circle
+  // - top of circle is min and max of range (clock, actual hours range [0,12])
+  //   - or set min and max of range (clock) by startAngle
+  // - long min,max = -180,180 so actual range is [-180,180]
+  // - avail axes are:
+  //  - degrees around edge
+  //  - distance from centre
+  //  - number of rotations
+  //  - direction of rotation
+  //  -
+
+
+
 const ctxMethods = 'arc arcTo beginPath bezierCurveTo clearRect clip closePath createImageData createLinearGradient createRadialGradient createPattern drawFocusRing drawImage fill fillRect fillText getImageData isPointInPath lineTo measureText moveTo putImageData quadraticCurveTo rect restore rotate save scale setTransform stroke strokeRect strokeText transform translate'.split(' ');
 const ctxProps = 'canvas fillStyle font globalAlpha globalCompositeOperation lineCap lineJoin lineWidth miterLimit shadowOffsetX shadowOffsetY shadowBlur shadowColor strokeStyle textAlign textBaseline'.split(' ');
 
@@ -280,10 +314,6 @@ const extraMethods = {
           lineCache[key].push(opts);
         }
 
-        //
-        // @TODO - don't use `fill` etc, pass in `styles` object,
-        //         each drawing method should use setStyle()
-
         // Drawing circles
         // - give either cx or cy, plus any other params you wanna set
         const drawCircle = ({ cx, cy, radius, start, end, rotate = 0, style }) => {
@@ -460,16 +490,6 @@ const extraMethods = {
           if (style) this.restore();
         }
 
-        // @TODO - add more drawing methods:
-        //
-        // - smooth lines                          https://stackoverflow.com/a/40978275/5479837
-        // - spider charts                         https://yangdanny97.github.io/blog/2019/03/01/D3-Spider-Chart
-        // - candlesticks:                         .candle({ open, close, low, high, green, red, whichAxis })
-        // - draw svg or fn(ctx, x, y):            .svg({ x, y, w, h , data })  where `data` is { '.a-selector': { 'fill':  data.foo }
-        // - small multiples                       https://www.juiceanalytics.com/writing/better-know-visualization-small-multiples
-        // - lollipops:                            ...just circles which draw a length to axis, or to lineLength (see https://www.d3-graph-gallery.com/lollipop.html)
-        // - parallell coords plot:                ...multiple Y axes, implicit/invisible X axis: https://datavizcatalogue.com/methods/parallel_coordinates.html
-
         // add drawing methods to `data[key][n][shape]`
         d['circle'] = drawCircle;
         d['bar'] = drawBar;
@@ -552,22 +572,6 @@ const extraMethods = {
   setStyle: function(obj) {
     setStyle(this, obj);
   },
-
-  //
-  // @TODO - a radial axis, that draws a circle, ticks extending inwards/outwards from the outside edge
-  //
-  // - see https://github.com/vasturiano/d3-radial-axis
-  // - rotate around and draw tick for each axis point, accounting for scale
-  // - spread range over 360, so always draw a full circle
-  // - top of circle is min and max of range (clock, actual hours range [0,12])
-  //   - or set min and max of range (clock) by startAngle
-  // - long min,max = -180,180 so actual range is [-180,180]
-  // - avail axes are:
-  //  - degrees around edge
-  //  - distance from centre
-  //  - number of rotations
-  //  - direction of rotation
-  //  -
 
   xAxis: function({ range, scale = 1, yPos = 0, tickLength = 5, label = false, labelBelow = true, tickLabelCentered = false, tickCentered = true, tickLabels }) {
     const { w, h, x, y } = getDimensions(this),

--- a/src/chart.js
+++ b/src/chart.js
@@ -1,28 +1,24 @@
 /*
  * Based on Canvas Context2D Wrapper <http://github.com/millermedeiros/CanvasContext2DWrapper>
  *
- * With additions shamelessly stolen from:
- *
- * -
- *
  */
 
   // @TODO - fixes and improvements
   //
-  // - sharper/crisper lines:  translate canvas by 0.5px, and round everything to 1px
   // - refactor: dont cache lines, draw them in the same func as the other shapes
   // - fix: use `clip` to remove inner circle of doughnuts/arcs, to it doesn't remove bits of the other shapes
   //    - fix: once `clip` fix is working, allow setting stroke lines on pie/doughnut/arc arc shapes
 
-
   // @TODO - more drawing methods:
   //
-  // - spider charts                         https://yangdanny97.github.io/blog/2019/03/01/D3-Spider-Chart
-  // - candlesticks:                         .candle({ open, close, low, high, green, red, whichAxis })
-  // - draw svg or fn(ctx, x, y):            .svg({ x, y, w, h , data })  where `data` is { '.a-selector': { 'fill':  data.foo }
-  // - parallell coords plot:                ...multiple Y axes, implicit/invisible X axis: https://datavizcatalogue.com/methods/parallel_coordinates.html
+  // - candlesticks:  .candle({ open, close, low, high, green, red, whichAxis })`
+  // - draw svg:      .svg({ x, y, w, h , data })  ..where `data` is { '.a-selector': { 'fill':  data.foo }
 
+  // @TODO - more chart types
   //
+  // - spider charts           https://yangdanny97.github.io/blog/2019/03/01/D3-Spider-Chart
+  // - parallell coords plot:  multiple Y axes, implicit/invisible X axis: https://datavizcatalogue.com/methods/parallel_coordinates.html
+
   // @TODO - a radial axis, that draws a circle, ticks extending inwards/outwards from the outside edge
   //
   // - see https://github.com/vasturiano/d3-radial-axis

--- a/src/chart.js
+++ b/src/chart.js
@@ -349,16 +349,16 @@ const extraMethods = {
               // x
               xFlipped
                 ? isVertical
-                  ? stacked ? x+w-(xDistance*n)-(centered+(barPadding/2)) : x+w-(barWidth*i)-(xDistance*n)+(centered/2)
+                  ? stacked ? x+w-(xDistance*n)-(barWidth+barPadding)/2 : x+w-(barWidth*i)-(xDistance*n)+(centered/2)
                   : stacked ? x+w-stackedBarOffset : x+w
                 : isVertical
-                  ? x+(xDistance*n)+(stacked ? barPadding-centered/2 : barWidth*i)-centered
+                  ? stacked ? x+(xDistance*n)-(barWidth+barPadding)/2 : x+(xDistance*n)+(barWidth*i)-centered
                   : x+stackedBarOffset,
               // y
               yFlipped
                 ? isVertical
                   ? y-h+(stacked ? stackedBarOffset : 0)
-                  : y-h+(barWidth*i)+(yDistance*n)-(barWidth)
+                  : stacked ? y-h+(yDistance*n)+barWidth/2 : y-h+(barWidth*i)+(yDistance*n)-(barWidth)
                 : isVertical
                   ? y-(stacked ? stackedBarOffset : 0)
                   : stacked ? y-(yDistance*n)+barWidth/2 : y-barWidth*i-(yDistance*n)+centered,

--- a/src/chart.js
+++ b/src/chart.js
@@ -191,157 +191,153 @@ const extraMethods = {
       let lineCache = {},
           drawLines = () => {};
 
-      // Delay rendering by 1 millisecond, to make the API more flexible -
-      // the axes, margins, etc, can be set in any order.
-      setTimeout(() => {
-        dataKeys.forEach((key, i) => {
-          data[key].forEach((d, n) => {
-            // Create our drawing methods here:
-            //
-            // NOTE: if scaling by 2 props, scale the circles, squares, etc,
-            // by the __square root__ of the value passed in.
-            // That makes the area scale linearly with the given value.
+      dataKeys.forEach((key, i) => {
+        data[key].forEach((d, n) => {
+          // Create our drawing methods here:
+          //
+          // NOTE: if scaling by 2 props, scale the circles, squares, etc,
+          // by the __square root__ of the value passed in.
+          // That makes the area scale linearly with the given value.
 
-            const drawLine = (opts) => {
-              lineCache[key] = lineCache[key] || [];
-              lineCache[key].push(opts);
-            }
+          const drawLine = (opts) => {
+            lineCache[key] = lineCache[key] || [];
+            lineCache[key].push(opts);
+          }
 
-            const drawCircle = ({ cx, cy, cr, fill }) => {
-              const useCx = (cx||cx===0),
-                    useCy = (cy||cy===0);
+          const drawCircle = ({ cx, cy, cr, fill }) => {
+            const useCx = (cx||cx===0),
+                  useCy = (cy||cy===0);
 
-              if (!useCx && !useCy) return;
+            if (!useCx && !useCy) return;
 
-              this.beginPath();
-              this.arc(
-                // x
-                xFlipped
-                  ? useCx
-                    // if user passed in cx
-                    ? (x+w)-((xDistance*cx)-(xDistance*minXRange))
-                    // if user didn't pass in cx
-                    : x+w-(xDistance*n)*xScale
-                  : useCx
-                    ? x+(xDistance*cx)-(xDistance*minXRange)
-                    : x+(xDistance*n)*xScale,
-                // y
-                yFlipped
-                  ? useCy
-                    // if user passed in cy
-                    ? ((y-h)+(yDistance*cy))-(yDistance*minYRange)
-                    // if user didn't pass in cy
-                    : y-h+(yDistance*n)*yScale
-                  : useCy
-                    // if user passed in cy
-                    ? y-(yDistance*cy)+(yDistance*minYRange)
-                    // if user didn't pass in cy
-                    : y-(yDistance*n)*yScale,
-                // radius
-                cr||5,
-                // start angle, end angle (in radians)
-                0, Math.PI*2
-              );
-              this.stroke();
-              if (fill) {
-                this.fillStyle = fill;
-                this.fill();
-              }
-              this.closePath();
-            }
-
-            const drawBar = ({ height, width, fill }) => {
-              const useHeight = (height||height===0),
-                    useWidth = (width||width===0);
-
-              if (!useWidth && !useHeight) return;
-
-              this.beginPath();
-              this.rect(
-                // x
-                xFlipped
-                  ? useHeight
-                    ? x+w-(xDistance*n)-xDistance/4
-                    : x+w
-                  : useHeight
-                    ? x+(xDistance*n)-xDistance/4
-                    : x,
-                // y
-                yFlipped
-                  ? useHeight
-                    ? y-h
-                    : (y-h)+(yDistance*n)+yDistance/2-yDistance/4
-                  : useHeight
-                    ? y
-                    : y-(yDistance*n)+yDistance/2-yDistance/4,
-                // w
-                xFlipped
-                  ? useWidth
-                    ? -(xDistance*width)+(xDistance*minXRange)
-                    : xDistance/2
-                  : useWidth
-                    ? (xDistance*width)-(xDistance*minXRange)
-                    : xDistance/2,
-                // h
-                yFlipped
-                  ? useHeight
-                    ? yDistance*height-(yDistance*minYRange)
-                    : -yDistance/2
-                  : useHeight
-                    ? -yDistance*height+(yDistance*minYRange)
-                    : -yDistance/2
-              );
-              this.stroke();
-              if (fill) {
-                this.fillStyle = fill;
-                this.fill();
-              }
-              this.closePath();
-            }
-
-            // add drawing methods to `data[key][n][shape]`
-            d['circle'] = drawCircle;
-            d['bar'] = drawBar;
-            d['line'] = drawLine;
-          });
-          // now run the given func on the decorated data
-          fn(data[key], key, i);
-        });
-
-        drawLines = () => {
-          const cachedLines = Object.keys(lineCache);
-          if (cachedLines.length < 1) return;
-          this.save();
-          cachedLines.forEach(key => {
             this.beginPath();
-            lineCache[key].forEach((line, i) => {
-              const { px, py, lineWidth, stroke } = lineCache[key][i],
-                    usePx = (px||px===0),
-                    usePy = (py||py===0);
-
-              if (!usePx && !usePy) return;
-              if (lineWidth) this.lineWidth = lineWidth;
-              if (stroke) this.strokeStyle = stroke;
-
-              const paramsX = xFlipped
-                ? usePx ? x+w-xDistance*px+(xDistance*minXRange) : (x+w)-((xDistance*(i))*xScale)
-                : usePx ? x+xDistance*px-(xDistance*minXRange) : x+((xDistance*(i))*xScale);
-
-              const paramsY = yFlipped
-                ? usePy ? (y-h)+(yDistance*py)-(yDistance*minYRange) : (y-h)+((yDistance*(i))*yScale)
-                : usePy ? y-yDistance*py+(yDistance*minYRange) : y-((yDistance*(i))*yScale)
-
-              if (i === 0) this.moveTo(paramsX, paramsY);
-              this.lineTo(paramsX, paramsY);
-              this.stroke();
-            });
+            this.arc(
+              // x
+              xFlipped
+                ? useCx
+                  // if user passed in cx
+                  ? (x+w)-((xDistance*cx)-(xDistance*minXRange))
+                  // if user didn't pass in cx
+                  : x+w-(xDistance*n)*xScale
+                : useCx
+                  ? x+(xDistance*cx)-(xDistance*minXRange)
+                  : x+(xDistance*n)*xScale,
+              // y
+              yFlipped
+                ? useCy
+                  // if user passed in cy
+                  ? ((y-h)+(yDistance*cy))-(yDistance*minYRange)
+                  // if user didn't pass in cy
+                  : y-h+(yDistance*n)*yScale
+                : useCy
+                  // if user passed in cy
+                  ? y-(yDistance*cy)+(yDistance*minYRange)
+                  // if user didn't pass in cy
+                  : y-(yDistance*n)*yScale,
+              // radius
+              cr||5,
+              // start angle, end angle (in radians)
+              0, Math.PI*2
+            );
+            this.stroke();
+            if (fill) {
+              this.fillStyle = fill;
+              this.fill();
+            }
             this.closePath();
+          }
+
+          const drawBar = ({ height, width, fill }) => {
+            const useHeight = (height||height===0),
+                  useWidth = (width||width===0);
+
+            if (!useWidth && !useHeight) return;
+
+            this.beginPath();
+            this.rect(
+              // x
+              xFlipped
+                ? useHeight
+                  ? x+w-(xDistance*n)-xDistance/4
+                  : x+w
+                : useHeight
+                  ? x+(xDistance*n)-xDistance/4
+                  : x,
+              // y
+              yFlipped
+                ? useHeight
+                  ? y-h
+                  : (y-h)+(yDistance*n)+yDistance/2-yDistance/4
+                : useHeight
+                  ? y
+                  : y-(yDistance*n)+yDistance/2-yDistance/4,
+              // w
+              xFlipped
+                ? useWidth
+                  ? -(xDistance*width)+(xDistance*minXRange)
+                  : xDistance/2
+                : useWidth
+                  ? (xDistance*width)-(xDistance*minXRange)
+                  : xDistance/2,
+              // h
+              yFlipped
+                ? useHeight
+                  ? yDistance*height-(yDistance*minYRange)
+                  : -yDistance/2
+                : useHeight
+                  ? -yDistance*height+(yDistance*minYRange)
+                  : -yDistance/2
+            );
+            this.stroke();
+            if (fill) {
+              this.fillStyle = fill;
+              this.fill();
+            }
+            this.closePath();
+          }
+
+          // add drawing methods to `data[key][n][shape]`
+          d['circle'] = drawCircle;
+          d['bar'] = drawBar;
+          d['line'] = drawLine;
+        });
+        // now run the given func on the decorated data
+        fn(data[key], key, i);
+      });
+
+      drawLines = () => {
+        const cachedLines = Object.keys(lineCache);
+        if (cachedLines.length < 1) return;
+        this.save();
+        cachedLines.forEach(key => {
+          this.beginPath();
+          lineCache[key].forEach((line, i) => {
+            const { px, py, lineWidth, stroke } = lineCache[key][i],
+                  usePx = (px||px===0),
+                  usePy = (py||py===0);
+
+            if (!usePx && !usePy) return;
+            if (lineWidth) this.lineWidth = lineWidth;
+            if (stroke) this.strokeStyle = stroke;
+
+            const paramsX = xFlipped
+              ? usePx ? x+w-xDistance*px+(xDistance*minXRange) : (x+w)-((xDistance*(i))*xScale)
+              : usePx ? x+xDistance*px-(xDistance*minXRange) : x+((xDistance*(i))*xScale);
+
+            const paramsY = yFlipped
+              ? usePy ? (y-h)+(yDistance*py)-(yDistance*minYRange) : (y-h)+((yDistance*(i))*yScale)
+              : usePy ? y-yDistance*py+(yDistance*minYRange) : y-((yDistance*(i))*yScale)
+
+            if (i === 0) this.moveTo(paramsX, paramsY);
+            this.lineTo(paramsX, paramsY);
+            this.stroke();
           });
-          this.restore();
-          lineCache = {};
-        }
-        drawLines();
-      }, 0);
+          this.closePath();
+        });
+        this.restore();
+        lineCache = {};
+      }
+      drawLines();
     }
   },
 
@@ -366,44 +362,39 @@ const extraMethods = {
     this._d.xTickDistance = distanceBetweenTicks;
     this._d.xLabels = [];
 
-    // Do the actual drawing of axes after a 1 millisecond timeout, so that
-    // each axis can access the props set above of the other, before trying to
-    // render - so users don't need to define the axes in a particular order.
-    setTimeout(() => {
-      drawAxisTicks(this, { w, h, x, y }, 'x', yPos, tickLength, distanceBetweenTicks, scale);
-      drawAxisLine(this,  { w, h, x, y }, 'x', yPos);
-      for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
-        const tickLabel = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
-        this._d.xLabels.push(tickLabel)
-        const py = (y+16+8)-(h/100*yPos);
-        if (!flippedAxis) {
-          this.moveTo(x+i,y);
-          this.fillText(
-            // text
-            tickLabel,
-            // x
-            centered ? x+i-(labelLength/2) : x+i,
-            // y
-            py,
-            // max width
-            labelLength
-          );
-        } else {
-          this.moveTo(x+w-i,y);
-          this.fillText(
-            // text
-            tickLabel,
-            // x
-            centered ? x+w-i-(labelLength/2) : x+w-i,
-            // y
-            py,
-            // max width
-            labelLength
-          );
-        }
-        p++;
+    drawAxisTicks(this, { w, h, x, y }, 'x', yPos, tickLength, distanceBetweenTicks, scale);
+    drawAxisLine(this,  { w, h, x, y }, 'x', yPos);
+    for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
+      const tickLabel = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
+      this._d.xLabels.push(tickLabel)
+      const py = (y+16+8)-(h/100*yPos);
+      if (!flippedAxis) {
+        this.moveTo(x+i,y);
+        this.fillText(
+          // text
+          tickLabel,
+          // x
+          centered ? x+i-(labelLength/2) : x+i,
+          // y
+          py,
+          // max width
+          labelLength
+        );
+      } else {
+        this.moveTo(x+w-i,y);
+        this.fillText(
+          // text
+          tickLabel,
+          // x
+          centered ? x+w-i-(labelLength/2) : x+w-i,
+          // y
+          py,
+          // max width
+          labelLength
+        );
       }
-    }, 0);
+      p++;
+    }
 
     if (label) {
       this.fillText(label, (x+w/2)-(labelLength/2), below ? y+(16*3) : y-16, labelLength);
@@ -416,36 +407,32 @@ const extraMethods = {
           theRange = getRange(range),
           distanceBetweenTicks = Math.abs(h / theRange);
 
-      let tickLabelWidth,
-          maxLabelWidth = 0;
+    let maxLabelWidth = 0;
 
     this._d.yRange = range;
     this._d.yScale = scale;
     this._d.yTickDistance = distanceBetweenTicks;
     this._d.yLabels = [];
 
-    // Do the actual drawing of axes after a 1 millisecond timeout, so that
-    // each axis can access the props set above of the other, before trying to
-    // render - so users don't need to define the axes in a particular order.
-    setTimeout(() => {
-      drawAxisTicks(this, { w, h, x, y }, 'y', xPos, tickLength, distanceBetweenTicks, scale);
-      drawAxisLine(this,  { w, h, x, y }, 'y', xPos);
-      for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
-        const tickLabel = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
-        this._d.yLabels.push(tickLabel);
-        tickLabelWidth = `${tickLabel}`.length;
-        if (tickLabelWidth >= maxLabelWidth) maxLabelWidth = tickLabelWidth;
-        const px = x+(w/100*xPos)-(tickLabelWidth*6+16);
-        if (!flippedAxis) {
-          this.moveTo(x,y-i);
-          this.fillText(tickLabel, px, y-i+4);
-        } else {
-          this.moveTo(x,y-h-i);
-          this.fillText(tickLabel, px, (y-h)+i+2);
-        }
-        p++;
+    drawAxisTicks(this, { w, h, x, y }, 'y', xPos, tickLength, distanceBetweenTicks, scale);
+    drawAxisLine(this,  { w, h, x, y }, 'y', xPos);
+
+    for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
+      const tickLabel = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale),
+            tickLabelWidth = `${tickLabel}`.length;
+
+      if (tickLabelWidth >= maxLabelWidth) maxLabelWidth = tickLabelWidth;
+      this._d.yLabels.push(tickLabel);
+      const px = x+(w/100*xPos)-(tickLabelWidth*6+16);
+      if (!flippedAxis) {
+        this.moveTo(x,y-i);
+        this.fillText(tickLabel, px, y-i+4);
+      } else {
+        this.moveTo(x,y-h-i);
+        this.fillText(tickLabel, px, (y-h)+i+2);
       }
-    }, 0);
+      p++;
+    }
 
     if (label) {
       this.fillText(label, leftLabel ? x-(`${label}`.length*6)-32-(maxLabelWidth*6) : x+16, y+4-(h/2));

--- a/src/chart.js
+++ b/src/chart.js
@@ -60,6 +60,15 @@ const isFn = v => typeof v ==='function',
       getSumTotal = (array, prop) => array.reduce((prev, cur) => prev + cur[prop], 0);
 
 
+// clears a circular area on canvas, like clearRect, for circles
+//const clearCircle = (ctx, x, y, r) => {
+//    for(let i = 0; i < Math.round( Math.PI * r ); i++ ) {
+//        let angle = ( i / Math.round( Math.PI * r )) * 360;
+//        ctx.clearRect( x , y , Math.sin( angle * ( Math.PI / 180 )) * r , Math.cos( angle * ( Math.PI / 180 )) * r );
+//    }
+//}
+
+
 // returns the scaled value of the given position in the given range
 //const scale = ({ range, scale, position }) => {
 //  const [min, max] = range;
@@ -261,7 +270,7 @@ const extraMethods = {
             this.closePath();
           };
 
-          const drawPieSlice = ({ px, py, radius = w-(w/100*50), slice = 0, fill }) => {
+          const drawPieSlice = ({ px, py, radius = w-(w/100*50), innerRadius = 0, slice = 0, fill }) => {
             // dont draw anything if blank data
             if (Object.keys(d).length < 4) return;
             const paramX = px||x+w/2,
@@ -279,7 +288,6 @@ const extraMethods = {
             this.arc(
               paramX,
               paramY,
-              // radius
               radius,
               // start angle (in radians)
               deg2rad(currentPieDeg),
@@ -295,6 +303,17 @@ const extraMethods = {
               this.fill();
             }
             this.stroke();
+            if (innerRadius) {
+              this.save();
+              this.globalCompositeOperation = "destination-out";
+              this.beginPath();
+              this.arc(paramX, paramY, innerRadius, 0, Math.PI*2, false);
+              this.moveTo(radius, 0);
+              this.fill();
+              this.globalCompositeOperation = "source-over";
+              this.stroke();
+              this.restore();
+            }
             this.closePath();
             currentPieDeg += sliceInDeg;
           }

--- a/src/chart.js
+++ b/src/chart.js
@@ -350,7 +350,7 @@ const extraMethods = {
               xFlipped
                 ? isVertical
                   ? stacked ? x+w-(xDistance*n)-(centered+(barPadding/2)) : x+w-(barWidth*i)-(xDistance*n)+(centered/2)
-                  : x+w
+                  : stacked ? x+w-stackedBarOffset : x+w
                 : isVertical
                   ? x+(xDistance*n)+(stacked ? barPadding-centered/2 : barWidth*i)-centered
                   : x+stackedBarOffset,
@@ -369,7 +369,7 @@ const extraMethods = {
                   : -(xDistance*(stacked ? barHeight : width))+(xDistance*minXRange)
                 : isVertical
                   ? stacked ? xDistance-barPadding: barWidth
-                  : (xDistance*barHeight)-(xDistance*minXRange),
+                  : (xDistance*barHeight)-(stacked ? 0 : xDistance*minXRange),
               // h
               yFlipped
                 ? isVertical

--- a/src/chart.js
+++ b/src/chart.js
@@ -105,11 +105,13 @@ function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, distan
     for (let i=0, p=0; i<=max; i+=distanceBetweenTicks*scale){
       ctx.beginPath();
       if (whichAxis === 'x'){
-        ctx.moveTo(x+i,y);
-        ctx.lineTo(x+i,y-(tickLength/100*h))
+        const py = pos < 50 ? y : y-h;
+        ctx.moveTo(x+i,py);
+        ctx.lineTo(x+i,py-(tickLength/100*h))
       } else {
-        ctx.moveTo(x,y-i);
-        ctx.lineTo(x+(tickLength/100*w),y-i);
+        const px = pos < 50 ? x : x+w;
+        ctx.moveTo(px,y-i);
+        ctx.lineTo(px+(tickLength/100*w),y-i);
       }
       ctx.stroke();
       ctx.closePath();
@@ -165,7 +167,7 @@ const extraMethods = {
     this.prevData = this.d;
     // If `data` if a func, run it, passing in the previous data (which
     // might be useful), else, just set the given data.
-    this.d = typeof data === 'function' ? data(this.prevData) : data;
+    this.d = typeof data === 'function' ? data(this.prevData) : { ...data };
     // internal chart data, used to calculate positions, sizes, etc
     this._d = this._d || {};
   },
@@ -369,7 +371,7 @@ const extraMethods = {
     for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
       const tickLabel = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
       this._d.xLabels.push(tickLabel)
-      const py = (y+16+8)-(h/100*yPos);
+      const py = yPos <= 50 ? (y+16+8)-(h/100*yPos) : y-(h/100*yPos)-16;
       if (!flippedAxis) {
         this.moveTo(x+i,y);
         this.fillText(
@@ -399,7 +401,16 @@ const extraMethods = {
     }
 
     if (label) {
-      this.fillText(label, (x+w/2)-(labelLength/2), below ? y+(16*3) : y-16, labelLength);
+      this.fillText(
+      //text
+      label,
+      //x
+      (x+w/2)-(labelLength/2),
+      //y
+      below
+        ? y+(16*3)
+        : y-h-(16*2)-8
+      );
     }
   },
 
@@ -425,19 +436,46 @@ const extraMethods = {
 
       if (tickLabelWidth >= maxLabelWidth) maxLabelWidth = tickLabelWidth;
       this._d.yLabels.push(tickLabel);
-      const px = x+(w/100*xPos)-(tickLabelWidth*6+16);
+
+      const px = (xPos <= 50)
+        ? x-16-(tickLabelWidth*6)+(w/100*xPos)
+        : x+(w/100*xPos)+16;
+
       if (!flippedAxis) {
-        this.moveTo(x,y-i);
-        this.fillText(tickLabel, px, y-i+4);
+        this.moveTo(
+          x,
+          y-i
+        );
+        this.fillText(
+          tickLabel,
+          px,
+          y-i+4
+        );
       } else {
-        this.moveTo(x,y-h-i);
-        this.fillText(tickLabel, px, (y-h)+i+2);
+        this.moveTo(
+          x,
+          y-h-i
+        );
+        this.fillText(
+          tickLabel,
+          px,
+          (y-h)+i+2
+        );
       }
       p++;
     }
 
     if (label) {
-      this.fillText(label, leftLabel ? x-(`${label}`.length*6)-32-(maxLabelWidth*6) : x+16, y+4-(h/2));
+      this.fillText(
+        // text
+        label,
+        // x
+        leftLabel
+          ? x-(`${label}`.length*6)-32-(maxLabelWidth*6)
+          : xPos <= 50 ? x+w+16 : x+w+32+(maxLabelWidth*6),
+        // y
+        y+4-(h/2)
+      );
     }
   },
 };

--- a/src/chart.js
+++ b/src/chart.js
@@ -177,17 +177,19 @@ const extraMethods = {
   drawEach: function(fn) {
     if (this.d) {
       const { w, h, x, y } = getDimensions(this),
-          minXRange = axisMin(this._d.xRange),
-          minYRange = axisMin(this._d.yRange),
-          xFlipped = isAxisFlipped(this._d.xRange),
-          yFlipped = isAxisFlipped(this._d.yRange),
-          xDistance = this._d.xTickDistance,
-          yDistance = this._d.yTickDistance,
-          xScale = this._d.xScale,
-          yScale = this._d.yScale,
+          _d = this._d,
+          minXRange = axisMin(_d.xRange),
+          minYRange = axisMin(_d.yRange),
+          xFlipped = isAxisFlipped(_d.xRange),
+          yFlipped = isAxisFlipped(_d.yRange),
+          xDistance = _d.xTickDistance,
+          yDistance = _d.yTickDistance,
+          xScale = _d.xScale,
+          yScale = _d.yScale,
           data = Array.isArray(this.d) ? { data: [ ...this.d ] } : { ...this.d },
           dataKeys = Object.keys(data),
           dataLength = dataKeys.length;
+
       let lineCache = {},
           drawLines = () => {};
 

--- a/src/chart.js
+++ b/src/chart.js
@@ -116,17 +116,18 @@ function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, tickCe
     ctx.save();
     ctx.lineWidth = lineWidth;
     ctx.strokeStyle = strokeStyle;
-
-    for (let i=0, p=0; i<=max+(tickCentered ? distanceBetweenTicks/4 : (whichAxis==='y'?-1:0)); i+=distanceBetweenTicks*scale){
+    for (let i=0, p=0; i<=max+(tickCentered ? distanceBetweenTicks/4 : 0); i+=distanceBetweenTicks*scale){
       ctx.beginPath();
-      if (whichAxis === 'x'){
-        const py = pos < 50 ? y : y-h;
-        ctx.moveTo(x+i+(centered),py);
-        ctx.lineTo(x+i+(centered),py-(tickLength/100*h))
-      } else {
-        const px = pos < 50 ? x : x+w;
-        ctx.moveTo(px,y-i-(centered));
-        ctx.lineTo(px+(tickLength/100*w),y-i-(centered));
+      if (whichAxis === 'x' && x+i+centered <= x+w) {
+        const px = x+i+centered,
+              py = pos < 50 ? y : y-h;
+        ctx.moveTo(px,py);
+        ctx.lineTo(px,py-(tickLength/100*h))
+      } else if (y-i-centered >= y-h) {
+        const px = pos < 50 ? x : x+w,
+              py = y-i-centered;
+        ctx.moveTo(px,py);
+        ctx.lineTo(px+(tickLength/100*w),py);
       }
       ctx.stroke();
       ctx.closePath();

--- a/src/chart.js
+++ b/src/chart.js
@@ -354,7 +354,7 @@ const extraMethods = {
     }
   },
 
-  xAxis: function(range, scale = 1, yPos = 0, tickLength = 5, label = false, centered = false, below = true) {
+  xAxis: function(range, scale = 1, yPos = 0, tickLength = 5, label = false, below = true, centered = false, tickLabels) {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
@@ -369,7 +369,13 @@ const extraMethods = {
     drawAxisTicks(this, { w, h, x, y }, 'x', yPos, yPos <= 50 ? tickLength : -tickLength, distanceBetweenTicks, scale);
     drawAxisLine(this,  { w, h, x, y }, 'x', yPos);
     for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
-      const tickLabel = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
+
+      const tickLabel = (typeof tickLabels[p]!=='undefined')
+        ? tickLabels[p]
+        : flippedAxis
+          ? range[1]+Math.abs(p*scale)
+          : range[0]+Math.abs(p*scale);
+
       this._d.xLabels.push(tickLabel)
       const py = yPos <= 50 ? (y+16+8)-(h/100*yPos) : y-(h/100*yPos)-16;
       if (!flippedAxis) {
@@ -412,7 +418,7 @@ const extraMethods = {
     }
   },
 
-  yAxis: function(range, scale = 1, xPos = 0, tickLength = 5, label = false, leftLabel = true) {
+  yAxis: function(range, scale = 1, xPos = 0, tickLength = 5, label = false, leftLabel = true, tickLabels) {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
@@ -429,8 +435,13 @@ const extraMethods = {
     drawAxisLine(this,  { w, h, x, y }, 'y', xPos);
 
     for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
-      const tickLabel = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale),
-            tickLabelWidth = `${tickLabel}`.length;
+      const tickLabel = (typeof tickLabels[p]==='undefined')
+        ? flippedAxis
+          ? range[1]+Math.abs(p*scale)
+          : range[0]+Math.abs(p*scale)
+        : tickLabels[p];
+
+      const tickLabelWidth = `${tickLabel}`.length;
 
       if (tickLabelWidth >= maxLabelWidth) maxLabelWidth = tickLabelWidth;
       this._d.yLabels.push(tickLabel);

--- a/src/chart.js
+++ b/src/chart.js
@@ -52,7 +52,12 @@ const PIXEL_RATIO = (function () {
 
 // helper funcs
 
-//const isFn = v => typeof v ==='function';
+const isFn = v => typeof v ==='function',
+      isArray = v => Array.isArray(v),
+      isAxisFlipped = range => isArray(range) ? range[0] > range[1] : false,
+      axisMin  = range => isArray(range) ? isAxisFlipped(range)?range[1]:range[0] : 0,
+      getRange = range => isArray(range) ? isAxisFlipped(range)?range[0]-range[1]:range[1]-range[0]: 0;
+
 
 // returns the scaled value of the given position in the given range
 //const scale = ({ range, scale, position }) => {
@@ -132,17 +137,13 @@ const getTickLabel = (range, flippedAxis, pos, scale, labels) => {
     ? labels[pos]
     : autoLabel;
 
-  if (typeof labels==='function') {
+  if (isFn(labels)) {
     tickLabel = labels(autoLabel, pos)
   }
 
   return tickLabel;
 }
 
-const isArray = v => Array.isArray(v),
-      isAxisFlipped = range => isArray(range) ? range[0] > range[1] : false,
-      axisMin  = range => isArray(range) ? isAxisFlipped(range)?range[1]:range[0] : 0,
-      getRange = range => isArray(range) ? isAxisFlipped(range)?range[0]-range[1]:range[1]-range[0]: 0;
 
 // Now define the extra methods to add/bind to our extended 2d canvas context
 const extraMethods = {
@@ -186,7 +187,7 @@ const extraMethods = {
     this.prevData = this.d;
     // If `data` if a func, run it, passing in the previous data (which
     // might be useful), else, just set the given data.
-    this.d = typeof data === 'function' ? data(this.prevData) : data;
+    this.d = isFn(data) ? data(this.prevData) : data;
     // internal chart data, used to calculate positions, sizes, etc
     this._d = this._d || {};
   },
@@ -207,7 +208,7 @@ const extraMethods = {
           yDistance = _d.yTickDistance,
           xScale = _d.xScale,
           yScale = _d.yScale,
-          data = Array.isArray(this.d) ? { data: [ ...this.d ] } : { ...this.d },
+          data = isArray(this.d) ? { data: [ ...this.d ] } : { ...this.d },
           dataKeys = Object.keys(data),
           dataLength = dataKeys.length;
 

--- a/src/chart.js
+++ b/src/chart.js
@@ -7,17 +7,16 @@
  *
  */
 
-  // @TODO - fixes
+  // @TODO - fixes and improvements
   //
   // - sharper/crisper lines:  translate canvas by 0.5px, and round everything to 1px
-  // -
-  //
-  //
+  // - refactor: dont cache lines, draw them in the same func as the other shapes
+  // - fix: use `clip` to remove inner circle of doughnuts/arcs, to it doesn't remove bits of the other shapes
+  //    - fix: once `clip` fix is working, allow setting stroke lines on pie/doughnut/arc arc shapes
 
 
-  // @TODO - add more drawing methods:
+  // @TODO - more drawing methods:
   //
-  // - rounded lines                         https://stackoverflow.com/a/40978275/5479837
   // - spider charts                         https://yangdanny97.github.io/blog/2019/03/01/D3-Spider-Chart
   // - candlesticks:                         .candle({ open, close, low, high, green, red, whichAxis })
   // - draw svg or fn(ctx, x, y):            .svg({ x, y, w, h , data })  where `data` is { '.a-selector': { 'fill':  data.foo }
@@ -27,17 +26,13 @@
   // @TODO - a radial axis, that draws a circle, ticks extending inwards/outwards from the outside edge
   //
   // - see https://github.com/vasturiano/d3-radial-axis
-  // - rotate around and draw tick for each axis point, accounting for scale
-  // - spread range over 360, so always draw a full circle
-  // - top of circle is min and max of range (clock, actual hours range [0,12])
-  //   - or set min and max of range (clock) by startAngle
-  // - long min,max = -180,180 so actual range is [-180,180]
+  // - x axis rotates around the circle
+  // - y axis reaches from centre to each tick on x axis
   // - avail axes are:
-  //  - degrees around edge
-  //  - distance from centre
+  //  - degrees around edge (x axis)
+  //  - distance from centre (y axis)
   //  - number of rotations
   //  - direction of rotation
-  //  -
 
 
 

--- a/src/chart.js
+++ b/src/chart.js
@@ -120,6 +120,25 @@ function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, distan
   }
 }
 
+// returns either a default tick label, generated from the given range, or
+// taken `labels` if an array, or the default is passed in `labels` if it's
+// a function, and whatever is returned is used
+const getTickLabel = (range, flippedAxis, pos, scale, labels) => {
+  const autoLabel = flippedAxis
+    ? range[1]+Math.abs(pos*scale)
+    : range[0]+Math.abs(pos*scale);
+
+  let tickLabel = (typeof labels[pos]!=='undefined')
+    ? labels[pos]
+    : autoLabel;
+
+  if (typeof labels==='function') {
+    tickLabel = labels(autoLabel, pos)
+  }
+
+  return tickLabel;
+}
+
 const isArray = v => Array.isArray(v),
       isAxisFlipped = range => isArray(range) ? range[0] > range[1] : false,
       axisMin  = range => isArray(range) ? isAxisFlipped(range)?range[1]:range[0] : 0,
@@ -368,14 +387,9 @@ const extraMethods = {
 
     drawAxisTicks(this, { w, h, x, y }, 'x', yPos, yPos <= 50 ? tickLength : -tickLength, distanceBetweenTicks, scale);
     drawAxisLine(this,  { w, h, x, y }, 'x', yPos);
-    for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
 
-      const tickLabel = (typeof tickLabels[p]!=='undefined')
-        ? tickLabels[p]
-        : flippedAxis
-          ? range[1]+Math.abs(p*scale)
-          : range[0]+Math.abs(p*scale);
-
+    for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale) {
+      const tickLabel = getTickLabel(range, flippedAxis, p, scale, tickLabels);
       this._d.xLabels.push(tickLabel)
       const py = yPos <= 50 ? (y+16+8)-(h/100*yPos) : y-(h/100*yPos)-16;
       if (!flippedAxis) {
@@ -430,11 +444,8 @@ const extraMethods = {
     drawAxisLine(this,  { w, h, x, y }, 'y', xPos);
 
     for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
-      const tickLabel = (typeof tickLabels[p]==='undefined')
-        ? flippedAxis
-          ? range[1]+Math.abs(p*scale)
-          : range[0]+Math.abs(p*scale)
-        : tickLabels[p];
+
+      const tickLabel = getTickLabel(range, flippedAxis, p, scale, tickLabels);
 
       const tickLabelWidth = `${tickLabel}`.length;
 

--- a/src/chart.js
+++ b/src/chart.js
@@ -366,14 +366,13 @@ const extraMethods = {
     this._d.xTickDistance = distanceBetweenTicks;
     this._d.xLabels = [];
 
-    drawAxisTicks(this, { w, h, x, y }, 'x', yPos, tickLength, distanceBetweenTicks, scale);
+    drawAxisTicks(this, { w, h, x, y }, 'x', yPos, yPos <= 50 ? tickLength : -tickLength, distanceBetweenTicks, scale);
     drawAxisLine(this,  { w, h, x, y }, 'x', yPos);
     for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
       const tickLabel = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
       this._d.xLabels.push(tickLabel)
       const py = yPos <= 50 ? (y+16+8)-(h/100*yPos) : y-(h/100*yPos)-16;
       if (!flippedAxis) {
-        this.moveTo(x+i,y);
         this.fillText(
           // text
           tickLabel,
@@ -385,7 +384,6 @@ const extraMethods = {
           labelLength
         );
       } else {
-        this.moveTo(x+w-i,y);
         this.fillText(
           // text
           tickLabel,
@@ -427,7 +425,7 @@ const extraMethods = {
     this._d.yTickDistance = distanceBetweenTicks;
     this._d.yLabels = [];
 
-    drawAxisTicks(this, { w, h, x, y }, 'y', xPos, tickLength, distanceBetweenTicks, scale);
+    drawAxisTicks(this, { w, h, x, y }, 'y', xPos, xPos <= 50 ? tickLength : -tickLength, distanceBetweenTicks, scale);
     drawAxisLine(this,  { w, h, x, y }, 'y', xPos);
 
     for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
@@ -442,20 +440,12 @@ const extraMethods = {
         : x+(w/100*xPos)+16;
 
       if (!flippedAxis) {
-        this.moveTo(
-          x,
-          y-i
-        );
         this.fillText(
           tickLabel,
           px,
           y-i+4
         );
       } else {
-        this.moveTo(
-          x,
-          y-h-i
-        );
         this.fillText(
           tickLabel,
           px,

--- a/src/chart.js
+++ b/src/chart.js
@@ -345,79 +345,44 @@ const extraMethods = {
             let stackedBarOffset = prevData ? totalHeight*yDistance : 0;
 
             this.beginPath();
-            if (stacked) {
-              this.rect(
-                // x
-                xFlipped
-                  ? heightIsFromData
-                    ? x+w-(xDistance*n)-(stacked ? centered+(barPadding/2) : 0)
-                    : x+w
-                  : heightIsFromData
-                    ? x+(xDistance*n)-(stacked ? centered+(barPadding/2) : 0)
-                    : x,
-                // y
-                yFlipped
-                  ? heightIsFromData
-                    ? y-h+(stackedBarOffset)
-                    : y-h+(barWidth*i)+(yDistance*n)-(barWidth/2)
-                  : heightIsFromData
-                    ? y-(stackedBarOffset)
-                    : y-(barWidth*i)-(yDistance*n)+centered,
-                // w
-                xFlipped
-                  ? widthIsFromData
-                    ? -(xDistance*barHeight)+(xDistance*minXRange)
-                    : stacked ? xDistance-barPadding: barWidth
-                  : widthIsFromData
-                    ? (xDistance*barHeight)-(xDistance*minXRange)
-                    : stacked ? xDistance-barPadding: barWidth,
-                // h
-                yFlipped
-                  ? heightIsFromData
-                    ? yDistance*barHeight-(yDistance*minYRange)
-                    : -barWidth
-                  : heightIsFromData
-                    ? -yDistance*barHeight+(yDistance*minYRange)
-                    : -barWidth
-              );
-              stackedBarOffsets[i].push(barHeight); // store all bar heights for this dataset
-            } else {
-              this.rect(
-                // x
-                xFlipped
-                  ? heightIsFromData
-                    ? x+w-(barWidth*i)-(xDistance*n)+centered
-                    : x+w
-                  : heightIsFromData
-                    ? x+(barWidth*i)+(xDistance*n)-centered
-                    : x,
-                // y
-                yFlipped
-                  ? heightIsFromData
-                    ? y-h
-                    : y-h+(barWidth*i)+(yDistance*n)-(barWidth/2)
-                  : heightIsFromData
-                    ? y
-                    : y-(barWidth*i)-(yDistance*n)+centered,
-                // w
-                xFlipped
-                  ? widthIsFromData
-                    ? -(xDistance*width)+(xDistance*minXRange)
-                    : barWidth
-                  : widthIsFromData
-                    ? (xDistance*width)-(xDistance*minXRange)
-                    : barWidth,
-                // h
-                yFlipped
-                  ? heightIsFromData
-                    ? yDistance*height-(yDistance*minYRange)
-                    : -barWidth
-                  : heightIsFromData
-                    ? -yDistance*height+(yDistance*minYRange)
-                    : -barWidth
-              );
-            }
 
+            this.rect(
+              // x
+              xFlipped
+                ? heightIsFromData
+                  ? stacked ? x+w-(xDistance*n)-(centered+(barPadding/2)) : x+w-(barWidth*i)-(xDistance*n)+(centered/2)
+                  : x+w
+                : heightIsFromData
+                  ? x+(xDistance*n)+(stacked ? barPadding-centered/2 : barWidth*i)-centered
+                  : x,
+              // y
+              yFlipped
+                ? heightIsFromData
+                  ? y-h+(stacked ? stackedBarOffset : 0)
+                  : y-h+(barWidth*i)+(yDistance*n)-(barWidth/2)
+                : heightIsFromData
+                  ? y-(stacked ? stackedBarOffset : 0)
+                  : y-(barWidth*i)-(yDistance*n)+centered,
+              // w
+              xFlipped
+                ? widthIsFromData
+                  ? -(xDistance*(stacked ? barHeight : width))+(xDistance*minXRange)
+                  : stacked ? xDistance-barPadding: barWidth
+                : widthIsFromData
+                  ? (xDistance*barHeight)-(xDistance*minXRange)
+                  : stacked ? xDistance-barPadding: barWidth,
+              // h
+              yFlipped
+                ? heightIsFromData
+                  ? yDistance*(stacked ? barHeight : height)-(stacked ? 0 : yDistance*minYRange)
+                  : -barWidth
+                : heightIsFromData
+                  ? -yDistance*(stacked ? barHeight : height)+(stacked ? 0 : yDistance*minYRange)
+                  : -barWidth
+            );
+            // store all bar heights for this dataset
+            if (stacked) stackedBarOffsets[i].push(barHeight);
+            // draw it
             this.stroke();
             if (fill) {
               this.fillStyle = fill;

--- a/src/chart.js
+++ b/src/chart.js
@@ -167,7 +167,7 @@ const extraMethods = {
     this.prevData = this.d;
     // If `data` if a func, run it, passing in the previous data (which
     // might be useful), else, just set the given data.
-    this.d = typeof data === 'function' ? data(this.prevData) : { ...data };
+    this.d = typeof data === 'function' ? data(this.prevData) : data;
     // internal chart data, used to calculate positions, sizes, etc
     this._d = this._d || {};
   },
@@ -385,10 +385,7 @@ const extraMethods = {
           // x
           centered ? x+i-(labelLength/2) : x+i,
           // y
-          py,
-          // max width
-          labelLength
-        );
+          py);
       } else {
         this.fillText(
           // text
@@ -396,9 +393,7 @@ const extraMethods = {
           // x
           centered ? x+w-i-(labelLength/2) : x+w-i,
           // y
-          py,
-          // max width
-          labelLength
+          py
         );
       }
       p++;
@@ -451,17 +446,9 @@ const extraMethods = {
         : x+(w/100*xPos)+16;
 
       if (!flippedAxis) {
-        this.fillText(
-          tickLabel,
-          px,
-          y-i+4
-        );
+        this.fillText(tickLabel, px, y-i+4);
       } else {
-        this.fillText(
-          tickLabel,
-          px,
-          (y-h)+i+2
-        );
+        this.fillText(tickLabel, px, (y-h)+i+2);
       }
       p++;
     }

--- a/src/chart.js
+++ b/src/chart.js
@@ -172,7 +172,7 @@ const extraMethods = {
           yDistance = this._d.yTickDistance,
           xScale = this._d.xScale,
           yScale = this._d.yScale,
-          data = { ...this.d },
+          data = Array.isArray(this.d) ? { data: [ ...this.d ] } : { ...this.d },
           dataKeys = Object.keys(data),
           dataLength = dataKeys.length;
       let lineCache = {},
@@ -180,7 +180,6 @@ const extraMethods = {
 
       dataKeys.forEach((key, i) => {
         data[key].forEach((d, n) => {
-
           // Create our drawing methods here:
           //
           // NOTE: if scaling by 2 props, scale the circles, squares, etc,

--- a/src/chart.js
+++ b/src/chart.js
@@ -85,7 +85,7 @@ function drawAxisLine(ctx, dimensions, whichAxis = 'x', lineWidth = 0.5, strokeS
 }
 
 // draws the ticks along the axis, used by xAxis and yAxis
-function drawAxisTicks(ctx, dimensions, whichAxis = 'x', tickLength, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#555') {
+function drawAxisTicks(ctx, dimensions, whichAxis = 'x', tickLength, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#bbb') {
   const { w, h, x, y } = dimensions;
   const max = whichAxis === 'x' ? w : h;
 
@@ -98,10 +98,10 @@ function drawAxisTicks(ctx, dimensions, whichAxis = 'x', tickLength, distanceBet
       ctx.beginPath();
       if (whichAxis === 'x'){
         ctx.moveTo(x+i,y);
-        ctx.lineTo(x+i,y-tickLength)
+        ctx.lineTo(x+i,y-(tickLength/100*h))
       } else {
         ctx.moveTo(x,y-i);
-        ctx.lineTo(x-5,y-i);
+        ctx.lineTo(x+(tickLength/100*w),y-i);
       }
       ctx.stroke();
       ctx.closePath();
@@ -256,7 +256,7 @@ const extraMethods = {
     }
   },
 
-  xAxis: function(range, scale = 1, tickLength = 5, label = false, centered = false) {
+  xAxis: function(range, scale = 1, tickLength = 5, label = false, centered = false, below = true) {
     const { w, h, x, y } = getAxisDimensions(this);
     const distanceBetweenTicks = w / (range[1]-range[0]);
 
@@ -264,8 +264,8 @@ const extraMethods = {
     this._d.xScale = scale;
     this._d.xTickDistance = distanceBetweenTicks;
 
-    drawAxisLine(this, { w, h, x, y }, 'x');
-    drawAxisTicks(this, { w, h, x, y }, 'x', tickLength, distanceBetweenTicks, scale, 0.5, 'red');
+    drawAxisLine(this,  { w, h, x, y }, 'x');
+    drawAxisTicks(this, { w, h, x, y }, 'x', tickLength, distanceBetweenTicks, scale);
 
     if (label) {
       for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
@@ -279,11 +279,11 @@ const extraMethods = {
         this.fillText(name, centered ? x+i-(label.length*6/2) : x+i, y+16+8, label.length*6);
         p++;
       }
-      this.fillText(label, (x+w/2)-(label.length*6/2), y+(16*2)+8, label.length*6);
+      this.fillText(label, (x+w/2)-(label.length*6/2), below ? y+(16*2)+8 : y-16, label.length*6);
     }
   },
 
-  yAxis: function(range, scale = 1, tickLength = 5, label = false) {
+  yAxis: function(range, scale = 1, tickLength = 5, label = false, leftLabel = true) {
     const { w, h, x, y } = getAxisDimensions(this);
     const distanceBetweenTicks = h / (range[1]-range[0]);
 
@@ -291,8 +291,8 @@ const extraMethods = {
     this._d.yScale = scale;
     this._d.yTickDistance = distanceBetweenTicks;
 
-    drawAxisLine(this, { w, h, x, y }, 'y');
-    drawAxisTicks(this, { w, h, x, y }, 'y', tickLength, distanceBetweenTicks, scale, 0.5, 'blue');
+    drawAxisLine(this,  { w, h, x, y }, 'y');
+    drawAxisTicks(this, { w, h, x, y }, 'y', tickLength, distanceBetweenTicks, scale);
 
     let nameWidth;
     let maxNameWidth = 0;
@@ -310,7 +310,7 @@ const extraMethods = {
         this.fillText(name, x-(nameWidth*6)-16, y-i+4);
         p++;
       }
-      this.fillText(label, x-(`${label}`.length*6)-32-(maxNameWidth*6), y+4-(h/2));
+      this.fillText(label, leftLabel ? x-(`${label}`.length*6)-32-(maxNameWidth*6) : x+16, y+4-(h/2));
     }
   },
 };

--- a/src/chart.js
+++ b/src/chart.js
@@ -110,6 +110,9 @@ function drawAxisTicks(ctx, dimensions, whichAxis = 'x', tickLength, distanceBet
   }
 }
 
+const isAxisFlipped = range => range[0] > range[1];
+const axisMin = range => isAxisFlipped(range) ? range[1] : range[0];
+const getRange = range => isAxisFlipped(range) ? range[0]-range[1] : range[1]-range[0];
 
 // Now define the extra methods to add/bind to our extended 2d canvas context
 const extraMethods = {
@@ -157,10 +160,8 @@ const extraMethods = {
   each: function(fn) {
     const { w, h, x, y } = getAxisDimensions(this);
     if (this.d) {
-      const isXFlipped = this._d.xRange[0] > this._d.xRange[1];
-      const isYFlipped = this._d.yRange[0] > this._d.yRange[1];
-      const minXRange = isXFlipped ? this._d.xRange[1] : this._d.xRange[0];
-      const minYRange = isYFlipped ? this._d.yRange[1] : this._d.yRange[0];
+      const minXRange = axisMin(this._d.xRange);
+      const minYRange = axisMin(this._d.yRange);
       const data = { ...this.d };
       const dataKeys = Object.keys(data);
       let lineCache = {};
@@ -271,8 +272,8 @@ const extraMethods = {
 
   xAxis: function(range, scale = 1, tickLength = 5, label = false, centered = false, below = true) {
     const { w, h, x, y } = getAxisDimensions(this);
-    const isFlipped = range[0] > range[1];
-    const theRange = isFlipped ? range[0]-range[1] : range[1]-range[0];
+    const flippedAxis = range[0] > range[1];
+    const theRange = getRange(range);
     const distanceBetweenTicks = Math.abs(w / theRange);
 
     this._d.xRange = range;
@@ -289,9 +290,9 @@ const extraMethods = {
           ? this.d[p][label.toLowerCase()]*scale
           : '';
         if (this.d.length-1 !== theRange) {
-          name = isFlipped ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
+          name = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
         }
-        if (!isFlipped) {
+        if (!flippedAxis) {
           this.moveTo(x+i,y);
           this.fillText(name, centered ? x+i-(labelLength/2) : x+i, y+16+8, labelLength);
         } else {
@@ -306,8 +307,8 @@ const extraMethods = {
 
   yAxis: function(range, scale = 1, tickLength = 5, label = false, leftLabel = true) {
     const { w, h, x, y } = getAxisDimensions(this);
-    const isFlipped = range[0] > range[1];
-    const theRange = isFlipped ? range[0]-range[1] : range[1]-range[0];
+    const flippedAxis = range[0] > range[1];
+    const theRange = getRange(range);
     const distanceBetweenTicks = Math.abs(h / theRange);
 
     this._d.yRange = range;
@@ -325,12 +326,12 @@ const extraMethods = {
           ? this.d[p][label.toLowerCase()]*scale
           : '';
         if (this.d.length-1 !== theRange) {
-          name = isFlipped ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
+          name = flippedAxis ? range[1]+Math.abs(p*scale) : range[0]+Math.abs(p*scale);
         }
         nameWidth = `${name}`.length;
         if (nameWidth >= maxNameWidth) maxNameWidth = nameWidth;
         const xPos = x-(nameWidth*6)-16;
-        if (!isFlipped) {
+        if (!flippedAxis) {
           this.moveTo(x,y-i);
           this.fillText(name, xPos, y-i+4);
         } else {

--- a/src/chart.js
+++ b/src/chart.js
@@ -350,10 +350,10 @@ const extraMethods = {
                 // x
                 xFlipped
                   ? heightIsFromData
-                    ? x+w-(xDistance*n)+centered
+                    ? x+w-(xDistance*n)-(stacked ? centered+(barPadding/2) : 0)
                     : x+w
                   : heightIsFromData
-                    ? x+(xDistance*n)-(stacked ? centered : 0)
+                    ? x+(xDistance*n)-(stacked ? centered+(barPadding/2) : 0)
                     : x,
                 // y
                 yFlipped
@@ -367,7 +367,7 @@ const extraMethods = {
                 xFlipped
                   ? widthIsFromData
                     ? -(xDistance*barHeight)+(xDistance*minXRange)
-                    : barWidth
+                    : stacked ? xDistance-barPadding: barWidth
                   : widthIsFromData
                     ? (xDistance*barHeight)-(xDistance*minXRange)
                     : stacked ? xDistance-barPadding: barWidth,
@@ -381,7 +381,6 @@ const extraMethods = {
                     : -barWidth
               );
               stackedBarOffsets[i].push(barHeight); // store all bar heights for this dataset
-              console.log('stackedBarOffsets', stackedBarOffsets);
             } else {
               this.rect(
                 // x

--- a/src/chart.js
+++ b/src/chart.js
@@ -99,7 +99,6 @@ const isFn = v => typeof v ==='function',
 //  return min + (position - min) * scale;
 //};
 
-
 const setStyle = (ctx, obj) => {
   let fixedProp;
   for(let prop in obj) {
@@ -154,13 +153,13 @@ function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, tickCe
     for (let i=0, p=0; i<=max+(tickCentered ? distanceBetweenTicks/4 : 0); i+=distanceBetweenTicks*scale){
       ctx.beginPath();
       if (whichAxis === 'x' && x+i+centered <= x+w) {
-        const px = x+i+centered,
-              py = pos < 50 ? y : y-h;
+        const px = Math.round(x+i+centered),
+              py = Math.round(pos < 50 ? y : y-h);
         ctx.moveTo(px,py);
         ctx.lineTo(px,py-(tickLength/100*h))
       } else if (y-i-centered >= y-h) {
-        const px = pos < 50 ? x : x+w,
-              py = y-i-centered;
+        const px = Math.round(pos < 50 ? x : x+w),
+              py = Math.round(y-i-centered);
         ctx.moveTo(px,py);
         ctx.lineTo(px+(tickLength/100*w),py);
       }
@@ -587,13 +586,13 @@ const extraMethods = {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
-          distanceBetweenTicks = Math.abs(w / theRange),
           labelLength = getTextWidth(this, label),
-          labelHeight = getTextHeight(this, label);
+          labelHeight = getTextHeight(this, label),
+          distanceBetweenTicks = Math.abs(w / theRange);
 
     this._d.xRange = range;
     this._d.xScale = scale;
-    this._d.xDistance = distanceBetweenTicks;
+    this._d.xDistance = Math.round(distanceBetweenTicks);
     this._d.xLabels = [];
 
     drawAxisTicks(this, { w, h, x, y }, 'x', yPos, yPos <= 50 ? tickLength : -tickLength, tickCentered, distanceBetweenTicks, scale);
@@ -630,15 +629,15 @@ const extraMethods = {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
-          distanceBetweenTicks = Math.abs(h / theRange),
           labelWidth = getTextWidth(this, label),
-          labelHeight = getTextHeight(this, label);
+          labelHeight = getTextHeight(this, label),
+          distanceBetweenTicks = Math.abs(h / theRange);
 
     let maxLabelWidth = 0;
 
     this._d.yRange = range;
     this._d.yScale = scale;
-    this._d.yDistance = distanceBetweenTicks;
+    this._d.yDistance = Math.round(distanceBetweenTicks);
     this._d.yLabels = [];
 
     drawAxisTicks(this, { w, h, x, y }, 'y', xPos, xPos <= 50 ? tickLength : -tickLength, tickCentered, distanceBetweenTicks, scale);

--- a/src/chart.js
+++ b/src/chart.js
@@ -325,14 +325,13 @@ const extraMethods = {
           }
 
           const drawBar = ({ height, width, fill, stacked = false, padding = 12 }) => {
-            const heightIsFromData = (height||height===0),
-                  widthIsFromData  = (width||width===0);
+            const isVertical = (height||height===0);
 
-            if (!widthIsFromData && !heightIsFromData) return;
+            if (!(width||width===0) && !isVertical) return;
 
-            const barPadding = heightIsFromData ? xDistance/100*padding : yDistance/100*padding,
-                  barWidth   = (heightIsFromData ? xDistance : yDistance)/dataLength-(barPadding/2),
-                  barHeight  = heightIsFromData ? height : width,
+            const barPadding = isVertical ? xDistance/100*padding : yDistance/100*padding,
+                  barWidth   = (isVertical ? xDistance : yDistance)/(stacked ? 1.25: dataLength)-(barPadding/2),
+                  barHeight  = isVertical ? height : width,
                   centered   = barWidth*dataLength/2;
 
             // accumulate the previous bar heights
@@ -342,41 +341,41 @@ const extraMethods = {
             });
 
             // set the stacked bar offset position
-            let stackedBarOffset = prevData ? totalHeight*yDistance : 0;
+            let stackedBarOffset = prevData ? totalHeight*(isVertical ? yDistance : xDistance) : 0;
 
             this.beginPath();
 
             this.rect(
               // x
               xFlipped
-                ? heightIsFromData
+                ? isVertical
                   ? stacked ? x+w-(xDistance*n)-(centered+(barPadding/2)) : x+w-(barWidth*i)-(xDistance*n)+(centered/2)
                   : x+w
-                : heightIsFromData
+                : isVertical
                   ? x+(xDistance*n)+(stacked ? barPadding-centered/2 : barWidth*i)-centered
-                  : x,
+                  : x+stackedBarOffset,
               // y
               yFlipped
-                ? heightIsFromData
+                ? isVertical
                   ? y-h+(stacked ? stackedBarOffset : 0)
-                  : y-h+(barWidth*i)+(yDistance*n)-(barWidth/2)
-                : heightIsFromData
+                  : y-h+(barWidth*i)+(yDistance*n)-(barWidth)
+                : isVertical
                   ? y-(stacked ? stackedBarOffset : 0)
-                  : y-(barWidth*i)-(yDistance*n)+centered,
+                  : stacked ? y-(yDistance*n)+barWidth/2 : y-barWidth*i-(yDistance*n)+centered,
               // w
               xFlipped
-                ? widthIsFromData
-                  ? -(xDistance*(stacked ? barHeight : width))+(xDistance*minXRange)
-                  : stacked ? xDistance-barPadding: barWidth
-                : widthIsFromData
-                  ? (xDistance*barHeight)-(xDistance*minXRange)
-                  : stacked ? xDistance-barPadding: barWidth,
+                ? isVertical
+                  ? stacked ? xDistance-barPadding: barWidth
+                  : -(xDistance*(stacked ? barHeight : width))+(xDistance*minXRange)
+                : isVertical
+                  ? stacked ? xDistance-barPadding: barWidth
+                  : (xDistance*barHeight)-(xDistance*minXRange),
               // h
               yFlipped
-                ? heightIsFromData
+                ? isVertical
                   ? yDistance*(stacked ? barHeight : height)-(stacked ? 0 : yDistance*minYRange)
                   : -barWidth
-                : heightIsFromData
+                : isVertical
                   ? -yDistance*(stacked ? barHeight : height)+(stacked ? 0 : yDistance*minYRange)
                   : -barWidth
             );

--- a/src/chart.js
+++ b/src/chart.js
@@ -177,13 +177,6 @@ const extraMethods = {
     return getDimensions(this);
   },
 
-  // charts and graphs
-  //
-  // @TODO  add one of these
-  // - https://github.com/si-mikey/cartesian
-  // - https://github.com/phenax/graph-plotting
-  // - https://github.com/frago12/graph.js
-
   data: function(data) {
     this.prevData = this.d;
     // If `data` if a func, run it, passing in the previous data (which
@@ -233,16 +226,13 @@ const extraMethods = {
         data[key].forEach((d, n) => {
           // Create our drawing methods here:
           //
-          // NOTE: if scaling by 2 props, scale the circles, squares, etc,
-          // by the __square root__ of the value passed in.
-          // That makes the area scale linearly with the given value.
-
+          // @TODO - don't use `fill` etc, pass in `styles` object,
+          //         each drawing method should use setStyle()
 
           const drawLine = (opts) => {
             lineCache[key] = lineCache[key] || [];
             lineCache[key].push(opts);
           }
-
 
           const drawCircle = ({ cx, cy, radius, start, end, rotate = 0, fill }) => {
             if (!cx && !cy) return;
@@ -271,11 +261,9 @@ const extraMethods = {
             this.closePath();
           };
 
-
           const drawPieSlice = ({ px, py, radius = w-(w/100*50), slice = 0, fill }) => {
             // dont draw anything if blank data
             if (Object.keys(d).length < 4) return;
-
             const paramX = px||x+w/2,
                   paramY = py||y-h/2,
                   // get name of key/prop that "slice" represents:
@@ -285,7 +273,7 @@ const extraMethods = {
                   // get the sum total in our dataset for that prop
                   sumTotal = getSumTotal(data[key], prop),
                   sliceAsPercOfTotal = slice/sumTotal*100,
-                  sliceInDeg = ((sliceAsPercOfTotal)*360/100);
+                  sliceInDeg = sliceAsPercOfTotal*360/100;
 
             this.beginPath();
             this.arc(
@@ -310,7 +298,6 @@ const extraMethods = {
             this.closePath();
             currentPieDeg += sliceInDeg;
           }
-
 
           const drawBar = ({ height, width, fill, padding = 12 }) => {
             const useHeight = (height||height===0),
@@ -365,6 +352,16 @@ const extraMethods = {
             this.closePath();
           }
 
+          // @TODO - add more drawing methods:
+          //
+          // - candlesticks:                      .candle({ start, end, min, max, green, red, axis })
+          // - svg file:                          .svg({ svg, x, y, h, w })
+          // - rescaled svg:                      .svg({ svg, sx, sy, sh, sw, dx, dy, dh, dh })
+          // - lines/polygons, drawn manually:    .poly({ x1,y1,x2,y2 })
+          // - stacked lines (area chart)         .area({})
+          // -
+
+
           // add drawing methods to `data[key][n][shape]`
           d['circle'] = drawCircle;
           d['bar'] = drawBar;
@@ -408,6 +405,12 @@ const extraMethods = {
       left: l,
       right: r,
     }
+  },
+
+  setStyle: function(obj) {
+    for(i in obj) {
+      this[i] = obj[i];
+    };
   },
 
   xAxis: function(range, scale = 1, yPos = 0, tickLength = 5, label = false, below = true, centered = false, tickLabels) {

--- a/src/chart.js
+++ b/src/chart.js
@@ -107,25 +107,26 @@ function drawAxisLine(ctx, dimensions, whichAxis = 'x', pos, lineWidth = 0.5, st
 }
 
 // draws the ticks along the axis, used by xAxis and yAxis
-function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#bbb') {
+function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, tickCentered, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#bbb') {
   const { w, h, x, y } = dimensions,
-        max = (whichAxis === 'x') ? w : h;
+        max = (whichAxis === 'x') ? w : h,
+        centered = tickCentered ? 0 : distanceBetweenTicks/2;
 
   if (tickLength !== 0) {
     ctx.save();
     ctx.lineWidth = lineWidth;
     ctx.strokeStyle = strokeStyle;
 
-    for (let i=0, p=0; i<=max; i+=distanceBetweenTicks*scale){
+    for (let i=0, p=0; i<=max+(tickCentered ? distanceBetweenTicks/4 : (whichAxis==='y'?-1:0)); i+=distanceBetweenTicks*scale){
       ctx.beginPath();
       if (whichAxis === 'x'){
         const py = pos < 50 ? y : y-h;
-        ctx.moveTo(x+i,py);
-        ctx.lineTo(x+i,py-(tickLength/100*h))
+        ctx.moveTo(x+i+(centered),py);
+        ctx.lineTo(x+i+(centered),py-(tickLength/100*h))
       } else {
         const px = pos < 50 ? x : x+w;
-        ctx.moveTo(px,y-i);
-        ctx.lineTo(px+(tickLength/100*w),y-i);
+        ctx.moveTo(px,y-i-(centered));
+        ctx.lineTo(px+(tickLength/100*w),y-i-(centered));
       }
       ctx.stroke();
       ctx.closePath();
@@ -543,7 +544,7 @@ const extraMethods = {
   //  - direction of rotation
   //  -
 
-  xAxis: function(range, scale = 1, yPos = 0, tickLength = 5, label = false, below = true, centered = false, tickLabels) {
+  xAxis: function({ range, scale = 1, yPos = 0, tickLength = 5, label = false, labelBelow = true, tickLabelCentered = false, tickCentered = true, tickLabels }) {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
@@ -555,7 +556,7 @@ const extraMethods = {
     this._d.xDistance = distanceBetweenTicks;
     this._d.xLabels = [];
 
-    drawAxisTicks(this, { w, h, x, y }, 'x', yPos, yPos <= 50 ? tickLength : -tickLength, distanceBetweenTicks, scale);
+    drawAxisTicks(this, { w, h, x, y }, 'x', yPos, yPos <= 50 ? tickLength : -tickLength, tickCentered, distanceBetweenTicks, scale);
     drawAxisLine(this,  { w, h, x, y }, 'x', yPos);
 
     for (let i=0, p=0; i<=(w+distanceBetweenTicks/2); i+=distanceBetweenTicks*scale) {
@@ -564,8 +565,8 @@ const extraMethods = {
 
       const py = yPos <= 50 ? (y+16+8)-(h/100*yPos) : y-(h/100*yPos)-16;
       const px = flippedAxis
-        ? centered ? x+w-i-(labelLength/2) : x+w-i
-        : centered ? x+i-(labelLength/2) : x+i;
+        ? tickLabelCentered ? x+w-i-(labelLength/2) : x+w-i
+        : tickLabelCentered ? x+i-(labelLength/2) : x+i;
 
       this.fillText(tickLabel, px, py);
       p++;
@@ -578,14 +579,14 @@ const extraMethods = {
       //x
       (x+w/2)-(labelLength/2),
       //y
-      below
+      labelBelow
         ? y+(16*3)
         : y-h-(16*2)-8
       );
     }
   },
 
-  yAxis: function(range, scale = 1, xPos = 0, tickLength = 5, label = false, leftLabel = true, tickLabels) {
+  yAxis: function({ range, scale = 1, xPos = 0, tickLength = 5, label = false, labelLeft = true, tickCentered = true, tickLabels }) {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
@@ -598,7 +599,7 @@ const extraMethods = {
     this._d.yDistance = distanceBetweenTicks;
     this._d.yLabels = [];
 
-    drawAxisTicks(this, { w, h, x, y }, 'y', xPos, xPos <= 50 ? tickLength : -tickLength, distanceBetweenTicks, scale);
+    drawAxisTicks(this, { w, h, x, y }, 'y', xPos, xPos <= 50 ? tickLength : -tickLength, tickCentered, distanceBetweenTicks, scale);
     drawAxisLine(this,  { w, h, x, y }, 'y', xPos);
 
     for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
@@ -621,7 +622,7 @@ const extraMethods = {
         // text
         label,
         // x
-        leftLabel
+        labelLeft
           ? x-(`${label}`.length*6)-32-(maxLabelWidth*6)
           : xPos <= 50 ? x+w+16 : x+w+32+(maxLabelWidth*6),
         // y

--- a/src/chart.js
+++ b/src/chart.js
@@ -1,0 +1,384 @@
+/*
+ * Based on Canvas Context2D Wrapper <http://github.com/millermedeiros/CanvasContext2DWrapper>
+ *
+ * With additions shamelessly stolen from:
+ *
+ * -
+ *
+ */
+
+const ctxMethods = 'arc arcTo beginPath bezierCurveTo clearRect clip closePath createImageData createLinearGradient createRadialGradient createPattern drawFocusRing drawImage fill fillRect fillText getImageData isPointInPath lineTo measureText moveTo putImageData quadraticCurveTo rect restore rotate save scale setTransform stroke strokeRect strokeText transform translate'.split(' ');
+const ctxProps = 'canvas fillStyle font globalAlpha globalCompositeOperation lineCap lineJoin lineWidth miterLimit shadowOffsetX shadowOffsetY shadowBlur shadowColor strokeStyle textAlign textBaseline'.split(' ');
+
+/**
+* Wrap function to enable method chaining.
+* @param {Function} fn	Function to be modified.
+* @param {Object} scope	Scope where function will be called.
+* @param {Object} chainReturn	Object returned to enable chaining.
+* @return {Function} Chainable function.
+* @private
+*/
+function chainMethod(fn, scope, chainReturn) {
+  return function() {
+    	return fn.apply(scope, arguments) || chainReturn;
+  };
+}
+
+/**
+* Convert properties into getter/setter methods enabling chaining.
+* @param {String} propName	Property name.
+* @param {Object} scope	Object that contain original property.
+* @param {Object} chainReturn	Object returned to enable chaining.
+* @return {Function} Chainable getter/setter for properties.
+* @private
+*/
+function chainProperty(propName, scope, chainReturn) {
+  return function(value) {
+  	if(typeof value === 'undefined') {
+  		return scope[propName];
+  	}else{
+  		scope[propName] = value;
+  		return chainReturn;
+  	}
+  };
+}
+
+const PIXEL_RATIO = (function () {
+  return typeof window !== 'undefined'
+    ? (window && window.devicePixelRatio) || 1
+    : 1;
+})();
+
+// calculate maths constants only once
+const PI = Math.PI;
+const PIx2 = PI * 2;
+const PIo2 = PI / 2
+const RAD2DEG = 180 / PI;
+const DEG2RAD = PI / 180;
+
+// helper funcs
+
+// used by xAxis and yAxis, returns the scaled value of the given position in the given range
+const scale = ({ range, scale, position }) => {
+  const [min, max] = range;
+  return min + (position - min) * scale;
+};
+
+
+// used by xAxis and yAxis, to setup nicer default margins, if none set
+const autoMargins = (obj) => {
+  ['top','bottom','left','right'].forEach(area => {
+    const needsFix = obj.margin[area] < 1;
+    switch (area) {
+      case 'top':
+      case 'right':
+        if (needsFix) obj.margin[area] = 40;
+        break;
+      case 'bottom':
+        if (needsFix) obj.margin[area] = 60;
+        break;
+      case 'left':
+        if (needsFix) obj.margin[area] = 120;
+        break;
+    }
+  });
+}
+
+// returns the dimensions of the chart/graph axes, taking margins into account
+function getAxisDimensions(obj) {
+  const w = obj.canvas.width-obj.margin.right-obj.margin.left;
+  const h = obj.canvas.height-obj.margin.top-obj.margin.bottom;
+  const x = 0+obj.margin.left;
+  const y = obj.margin.top+h;
+  return { w, h, x, y }  ;
+}
+
+// draws the main line of the axis, used by xAxis and yAxis
+function drawAxisLine(ctx, dimensions, whichAxis = 'x', lineWidth = 0.5, strokeStyle = '#222') {
+  const { w, h, x, y } = dimensions;
+  ctx.save();
+  ctx.lineWidth = lineWidth;
+  ctx.strokeStyle = strokeStyle;
+  ctx.beginPath();
+  ctx.moveTo(x,y);
+  whichAxis === 'x'
+    ? ctx.lineTo(x,y-h)
+    : ctx.lineTo(x+w,y);
+  ctx.closePath();
+  ctx.stroke();
+  ctx.restore()
+}
+
+// draws the ticks along the axis, used by xAxis and yAxis
+function drawAxisTicks(ctx, dimensions, whichAxis = 'x', tickLength, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#555') {
+  const { w, h, x, y } = dimensions;
+  const max = whichAxis === 'x' ? w : h;
+
+  if (tickLength !== 0) {
+    ctx.save();
+    ctx.lineWidth = lineWidth;
+    ctx.strokeStyle = strokeStyle;
+
+    for (let i=0, p=0; i<=max; i+=distanceBetweenTicks*scale){
+      ctx.beginPath();
+      if (whichAxis === 'x'){
+        ctx.moveTo(x+i,y);
+        ctx.lineTo(x+i,y-tickLength)
+      } else {
+        ctx.moveTo(x,y-i);
+        ctx.lineTo(x-5,y-i);
+      }
+      ctx.stroke();
+      ctx.closePath();
+    }
+    ctx.restore()
+  }
+}
+
+
+// Now define the extra methods to add/bind to our extended 2d canvas context
+const extraMethods = {
+
+  // general helper funcs
+  clear: function(resetTransform) {
+    if (resetTransform === true) this.setTransform(1, 0, 0, 1, 0, 0);
+    this.clearRect(0, 0, this.canvas.width * PIXEL_RATIO, this.canvas.height * PIXEL_RATIO);
+  },
+  size: function(w, h, a) {
+    if (this.w === w && this.h === h) return; // if no new size, just return
+    // if width or height not given, get them from aspect ratio
+    this.w = w ? w : h * a;
+    this.h = h ? h : w * a;
+    // respect device pixel ratio
+    this.canvas.width = this.w * PIXEL_RATIO;
+    this.canvas.height = this.h * PIXEL_RATIO;
+    // update the CSS too
+    this.canvas.style.width = this.w + 'px';
+    this.canvas.style.height = this.h + 'px';
+    this.canvas.style.objectFit = a ? 'contain' : null;
+    // adjust scale for pixel ratio
+    if (this.contextType === '2d' && PIXEL_RATIO !== 1) {
+      this.scale(PIXEL_RATIO, PIXEL_RATIO);
+    }
+  },
+
+  // charts and graphs
+  //
+  // @TODO  add one of these
+  // - https://github.com/si-mikey/cartesian
+  // - https://github.com/phenax/graph-plotting
+  // - https://github.com/frago12/graph.js
+
+  data: function(data) {
+    this.prevData = this.d;
+    this.d = data;
+    this._d = this._d || {};
+  },
+
+  each: function(fn) {
+    const { w, h, x, y } = getAxisDimensions(this);
+    if (this.d) {
+      const data = { ...this.d };
+      Object.keys(data).forEach((key, i) => {
+        data[key].forEach((item, n) => {
+          // decorate the data with pre-defined x, y, w, h, r (etc) values,
+          // to make drawing the data easier
+          // scales
+          item.w = w/Object.keys(this.d).length-8*this._d.xScale // 8 is padding
+          item.h = h/Object.keys(this.d).length-8*this._d.yScale // 8 is padding
+          item.r = 5
+          // positions
+          item.x = x+((this._d.xTickDistance*n)*this._d.xScale);
+          item.y = y-((this._d.yTickDistance*n)*this._d.yScale);
+
+          const drawLine = ({ px, py, stroke }) => {
+            this.beginPath();
+            this.lineTo(
+              px ? x+this._d.xTickDistance*px : item.x,
+              py ? y-this._d.yTickDistance*py : item.y,
+            );
+            this.save();
+            this.lineWidth = 2;
+            this.strokeStyle = stroke;
+            this.stroke();
+            this.restore();
+            this.closePath();
+          }
+
+          const drawCircle = ({ cx, cy, cr, fill }) => {
+            this.beginPath();
+            this.arc(
+              cx ? x+this._d.xTickDistance*cx : item.x,
+              cy ? y-this._d.yTickDistance*cy : item.y,
+              cr||item.r,
+              0, Math.PI*2
+            );
+            this.stroke();
+            if (fill) {
+              this.fillStyle = fill;
+              this.fill();
+            }
+            this.closePath();
+          }
+
+          const drawBar = ({ height, width, fill }) => {
+            this.beginPath();
+            this.rect(
+              height ? x+(this._d.xTickDistance*n)-this._d.xTickDistance/4 : x,
+              height ? y : y-(this._d.yTickDistance*n)+this._d.yTickDistance/2-this._d.yTickDistance/4,
+              width  ? this._d.xTickDistance*width   : this._d.xTickDistance/2,
+              height ? -this._d.yTickDistance*height : -this._d.yTickDistance/2
+            );
+            this.stroke();
+            if (fill) {
+              this.fillStyle = fill;
+              this.fill();
+            }
+            this.closePath();
+          }
+
+
+          // add drawing methods to `this.d[key][datum][method]`
+          item['circle'] = drawCircle;
+          item['bar'] = drawBar;
+          item['lines'] = drawLine;
+
+
+        });
+        // now run the given func on the decorated data
+        fn(this.d[key], key, i);
+      });
+    }
+  },
+
+  margin: function(t,b,l,r){
+    this.margin = {
+      top: t,
+      bottom: b,
+      left: l,
+      right: r,
+    }
+  },
+
+  xAxis: function(range, scale = 1, tickLength = 5, label = false, centered = false) {
+    const { w, h, x, y } = getAxisDimensions(this);
+    const distanceBetweenTicks = w / (range[1]-range[0]);
+
+    this._d.xRange = range;
+    this._d.xScale = scale;
+    this._d.xTickDistance = distanceBetweenTicks;
+
+    autoMargins(this);
+    drawAxisLine(this, { w, h, x, y }, 'x');
+    drawAxisTicks(this, { w, h, x, y }, 'x', tickLength, distanceBetweenTicks, scale, 0.5, 'red');
+
+    if (label) {
+      for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
+        let name = typeof this.d[p] !== 'undefined'
+          ? this.d[p][label.toLowerCase()]*scale
+          : 'NULL';
+        if (this.d.length-1 !== range[1]-range[0]) {
+          name=range[0]+p*scale;
+        }
+        this.moveTo(x+i,y);
+        this.fillText(name, centered ? x+i-(label.length*6/2) : x+i, y+16+8, label.length*6);
+        p++;
+      }
+      this.fillText(label, (x+w/2)-(label.length*6/2), y+(16*2)+8, label.length*6);
+    }
+  },
+
+  yAxis: function(range, scale = 1, tickLength = 5, label = false) {
+    const { w, h, x, y } = getAxisDimensions(this);
+    const distanceBetweenTicks = h / (range[1]-range[0]);
+
+    this._d.yRange = range;
+    this._d.yScale = scale;
+    this._d.yTickDistance = distanceBetweenTicks;
+
+    autoMargins(this);
+    drawAxisLine(this, { w, h, x, y }, 'y');
+    drawAxisTicks(this, { w, h, x, y }, 'y', tickLength, distanceBetweenTicks, scale, 0.5, 'blue');
+
+    let nameWidth;
+    let maxNameWidth = 0;
+    if (label) {
+      for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
+        let name = typeof this.d[p] !== 'undefined'
+          ? this.d[p][label.toLowerCase()]*scale
+          : 'NULL';
+        if (this.d.length-1 !== range[1]-range[0]) {
+          name=range[0]+p*scale;
+        }
+        nameWidth = `${name}`.length;
+        if (nameWidth >= maxNameWidth) maxNameWidth = nameWidth;
+        this.moveTo(x,y-i);
+        this.fillText(name, x-(nameWidth*6)-16, y-i+4);
+        p++;
+      }
+      this.fillText(label, x-(`${label}`.length*6)-32-(maxNameWidth*6), y+4-(h/2));
+    }
+  },
+};
+
+const extraMethodNames = Object.keys(extraMethods);
+
+
+// ...Now the main function to export
+
+/**
+* @class Canvas Context2D Wrapper.
+* @param {CanvasRenderingContext2D} origCtx	Canvas Context2D that will be wrapped.
+* @param {Component} c	the @scottjarvis/component to which the ctx is attached (optional)
+*/
+const Chart = function(origCtx, c) {
+  let n = ctxMethods.length;
+  let curProp;
+
+  /**
+   * Reference to Canvas Rendering Context 2D.
+   * @type CanvasRenderingContext2D
+   */
+  this.context = origCtx;
+
+  //wrap methods
+  while(n--) {
+  	curProp = ctxMethods[n];
+  	this[curProp] = chainMethod(origCtx[curProp], origCtx, this);
+  }
+
+  // wrap the extra methods
+  n = extraMethodNames.length;
+  while(n--) {
+  	curProp = extraMethodNames[n];
+  	this[curProp] = chainMethod(extraMethods[curProp], origCtx, this);
+  }
+
+  //convert properties into methods (getter/setter)
+  n = ctxProps.length;
+  while(n--) {
+  	curProp = ctxProps[n];
+  	this[curProp] = chainProperty(curProp, origCtx, this);
+  }
+
+  // the above code replaces context properties with methods in our new
+  // context, so put back the reference to the canvas element, cos we want it
+  this.canvas = origCtx.canvas;
+
+
+  // add more methods to the extended context - they're added here cos they're
+  // nested/namespaced under ctx.image.* and ctx.video.* and the above
+  // loops that make methods chainable don't handle nested objects
+
+  this.context.margin = {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  };
+
+  return;
+};
+
+
+export default Chart;

--- a/src/ctx.js
+++ b/src/ctx.js
@@ -318,79 +318,6 @@ const drawHead = function(ctx,x0,y0,x1,y1,x2,y2,style) {
 };
 
 
-// returns the scaled value of the given position in the given range
-const scale = ({ range, scale, position }) => {
-  const [min, max] = range;
-  return min + (position - min) * scale;
-};
-
-
-const autoMargins = (obj) => {
-  ['top','bottom','left','right'].forEach(area => {
-    const needsFix = obj.margin[area] < 1;
-    switch (area) {
-      case 'top':
-      case 'right':
-        if (needsFix) obj.margin[area] = 40;
-        break;
-      case 'bottom':
-        if (needsFix) obj.margin[area] = 60;
-        break;
-      case 'left':
-        if (needsFix) obj.margin[area] = 120;
-        break;
-    }
-  });
-}
-
-function getAxisDimensions(obj) {
-  const w = obj.canvas.width-obj.margin.right-obj.margin.left;
-  const h = obj.canvas.height-obj.margin.top-obj.margin.bottom;
-  const x = 0+obj.margin.left;
-  const y = obj.margin.top+h;
-  return { w, h, x, y }  ;
-}
-
-function drawAxisLine(ctx, dimensions, whichAxis = 'x', lineWidth = 0.5, strokeStyle = '#222') {
-  const { w, h, x, y } = dimensions;
-  ctx.save();
-  ctx.lineWidth = lineWidth;
-  ctx.strokeStyle = strokeStyle;
-  ctx.beginPath();
-  ctx.moveTo(x,y);
-  whichAxis === 'x'
-    ? ctx.lineTo(x,y-h)
-    : ctx.lineTo(x+w,y);
-  ctx.closePath();
-  ctx.stroke();
-  ctx.restore()
-}
-
-function drawAxisTicks(ctx, dimensions, whichAxis = 'x', tickLength, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#555') {
-  const { w, h, x, y } = dimensions;
-  const max = whichAxis === 'x' ? w : h;
-
-  if (tickLength !== 0) {
-    ctx.save();
-    ctx.lineWidth = lineWidth;
-    ctx.strokeStyle = strokeStyle;
-
-    for (let i=0, p=0; i<=max; i+=distanceBetweenTicks*scale){
-      ctx.beginPath();
-      if (whichAxis === 'x'){
-        ctx.moveTo(x+i,y);
-        ctx.lineTo(x+i,y-tickLength)
-      } else {
-        ctx.moveTo(x,y-i);
-        ctx.lineTo(x-5,y-i);
-      }
-      ctx.stroke();
-      ctx.closePath();
-    }
-    ctx.restore()
-  }
-}
-
 // Now define the extra methods to add/bind to our extended 2d canvas context
 const extraMethods = {
 
@@ -901,72 +828,6 @@ const extraMethods = {
     this.restore();
   },
 
-  data: function(data) {
-    this.prevData = this.d;
-    this.d = data;
-  },
-
-  margin: function(t,b,l,r){
-    this.margin = {
-      top: t,
-      bottom: b,
-      left: l,
-      right: r,
-    }
-  },
-
-  xAxis: function(range, scale = 1, tickLength = 5, label = false) {
-    const { w, h, x, y } = getAxisDimensions(this);
-    const distanceBetweenTicks = w / (range[1]-range[0]);
-
-    autoMargins(this);
-    drawAxisLine(this, { w, h, x, y }, 'x');
-    drawAxisTicks(this, { w, h, x, y }, 'x', tickLength, distanceBetweenTicks, scale, 0.5, 'red');
-
-    if (label) {
-      for (let i=0, p=0; i<=w; i+=distanceBetweenTicks*scale){
-        let name = typeof this.d[p] !== 'undefined'
-          ? this.d[p][label.toLowerCase()]*scale
-          : 'NULL';
-        if (this.d.length-1 !== range[1]-range[0]) {
-          name=range[0]+p*scale;
-        }
-        this.moveTo(x+i,y);
-        this.fillText(name, x+i, y+16+8, label.length*6);
-        p++;
-      }
-      this.fillText(label, (x+w/2)-(label.length*6/2), y+(16*2)+8, label.length*6);
-    }
-  },
-
-  yAxis: function(range, scale = 1, tickLength = 5, label = false) {
-    const { w, h, x, y } = getAxisDimensions(this);
-    const distanceBetweenTicks = h / (range[1]-range[0]);
-
-    autoMargins(this);
-    drawAxisLine(this, { w, h, x, y }, 'y');
-    drawAxisTicks(this, { w, h, x, y }, 'y', tickLength, distanceBetweenTicks, scale, 0.5, 'blue');
-
-    let nameWidth;
-    let maxNameWidth = 0;
-    if (label) {
-      for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
-        let name = typeof this.d[p] !== 'undefined'
-          ? this.d[p][label.toLowerCase()]*scale
-          : 'NULL';
-        if (this.d.length-1 !== range[1]-range[0]) {
-          name=range[0]+p*scale;
-        }
-        nameWidth = `${name}`.length;
-        if (nameWidth >= maxNameWidth) maxNameWidth = nameWidth;
-        this.moveTo(x,y-i);
-        this.fillText(name, x-(nameWidth*6)-16, y-i+4);
-        p++;
-      }
-      this.fillText(label, x-(`${label}`.length*6)-32-(maxNameWidth*6), y+4-(h/2));
-    }
-  },
-
   // helper function - creates an img element, caches it, then sets the
   // onload method up to draw the image, and returns the image element - all
   // that is left to do to it is set the src elsewhere
@@ -1130,39 +991,6 @@ const Ctx = function(origCtx, c) {
   // add more methods to the extended context - they're added here cos they're
   // nested/namespaced under ctx.image.* and ctx.video.* and the above
   // loops that make methods chainable don't handle nested objects
-
-  // @TODO  add one of these
-  // - https://github.com/si-mikey/cartesian
-  // - https://github.com/phenax/graph-plotting
-  // - https://github.com/frago12/graph.js
-
-  this.context.margin = {
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
-  };
-
-  // this.chart = {
-    // position: function(x,y){},
-    // title: function(text){},
-    // height: function(num){},
-    // width: function(num){},
-    // margins: function({ top, bottom, left, right }){},
-    // scale: function({ range, scale, position }) {
-      // const [min, max] = range;
-      // // returns the scaled value of the given position in the given range
-      // return min + (position - min) * scale;
-    // },
-    // xAxis: function(x, y, range, title) {},
-    // yAxis: function(x, y, range, title) {},
-    // ticks: function(x, y, length) {},
-    // label: function(x, y, text, size) {},
-    // draw:  function() {},
-//
-    // // draw a plottable x,y graph, with the given axes
-    // plot: function(w, h, xAxis, yAxis) {},
-  // };
 
   this.image = {
     // download canvas as an image file, called ${name}


### PR DESCRIPTION
## Charts

A chart/graph making add-on. 

Only 3.5kb minified & gzipped so far, also works standalone (`Component` not required).

- draw charts to canvas
- a chainable API, similar to `d3` but simpler to use
- so far, it supports:
  - scatter charts
  - bubble charts
  - line charts
  - area charts (layered & stacked)
  - bar charts (horizontal & vertical)
  - grouped bar charts (horizontal & vertical)
  - stacked bar charts (horizontal & vertical)
  - candlestick charts
  - pie & doughnut charts
  - arc or "gauge" charts
  - lollipop charts
  - mixed charts

**TO DO**
- DONE: **easier chart dimensions**
  - an optional `.dimensions()` method:
    - returns `{ x, y, h, w, margin, xRange, yRange, xScale, yScale, xDistance, yDistance }`
- DONE: **move axis** - allow placing an axes at given % of chart width/height
  - don't move chart area, only the axes around it
  - `xAxis()` takes a `yPos` param - a % value of the chart height
  - `yAxis()` takes a `xPos` param - a % value of the chart width
- DONE: **flip axis** - allow flipping/inverting chart X and Y axes:
  - just swap the range values for the axis you wanna flip
  - this should flip the chart area too!
- DONE: **improve axis tick labels**
  - allow customising tick labels - added new params to `.xAxis()` and `.yAxis()`: 
      - each axis now takes an optional `tickLabels` array, as the last param
      - the labels given will override any auto-generated tick labels 
      - can also pass in a func, which receives the default (auto-generated) tick label
      - Tip: include empty strings in `tickLabels` to "hide" specific tick labels
- DONE: **fix bars**
  - bars should  sit beside each other, they shouldn't overlay straight on top of each other
- DONE: **circle angles**
  - support passing in `start`, `end` and `rotation` (in degrees) to `circle()`
  - this enables drawing of circle segments/pacman shapes
- DONE: **pie charts**
  -  added `.pie({ px, py, radius, slice, fill })`
  - about the params:
    - `px`/`py` to place it
    - `radius` is the width/size of it
    - `slice` is the slice width, in degrees,
    - `fill` to colour it in
- DONE: **doughnut charts**
  - `pie()` now takes an optional `innerRadius` param, to create holes in the middle (doughnut charts) 
- DONE: **stacked bars**
  - add a `stacked` attr to `bar()`
  - to "stack", take the data point of the previous group/category, use that as the offset of the current one   
- DONE **area charts**
  - added `fill` and `stacked` attributes to `.line({...})` method
  - `fill` produces a "layered area chart", `fill` and `stacked` produces a "stacked area chart"
- DONE: **styling**
  - added helper method to set styles easier (used `setStyle()` from `Ctx`)
  - allow setting all styles, on every object - just pass in a `style` param to the drawing methods 
  - allow adjustable fonts (auto-adjust label positions based on font size, etc)
- DONE: **candlesticks**
  - for much more informative financial charts
  - a "candle" (rect) - open/close prices, if open<close it's red, else green
  - a "wick" (line extending out of bar) - shows high/low prices
  - example: `data.candle({ open, close, high, low, green, red, padding, style })`
- **add: colour scales**
  - allow creation of colour scales, mapped to data, but independant of x/y axes
  - support hls/hsla, hex/hexa, rgb/rgba as input colours
  - something like `.colourScale('name', [min,max], scale, [startColour, endColour])`
    - example: `.colourScale('temperature', [0,100], 5, ['#eee','#c00'])` // creates 20 colours
    - usage: `ctx.colours['temperature'](96) // returns '#c00'`
    - allow easy creation of **types** of colour scale:
      - **sequential**: e.g, from light red to ..., to dark red
        - good for a linear scale with start/end values, doesn't loop around
      - **categorical**: evenly spaced set of colours, from along the whole hue spectrum
        - good for getting colours for a "legend", pallettes not gradients
      - **all** - "all" the colours from start to end, from hue 0 
        - all of same brightness (default 50%) and saturation (default 100%) 
  - see `sinebow`, `rainbow` and `turbo` from [d3-scale-chromatic](https://github.com/d3/d3-scale-chromatic)


Addons:

- **animations**
  - just animate the data itself with the `tweenState` or `springTo`  add-ons :)
  - the `Ctx` add-on has a zoomable, pannable camera, and more shapes, plus save to video, image, etc
- **maps + charts**
  - make it play nice with the `Geo` add-on
- **audio visualisations**
  - make it play nice with the `useAudio` add-on, which can do audio visualisation stuff 


### Usage:

```js
      ctx.beginPath()

      .useData({
        'USA': [{}, // pad with an empty year.. just to create more space on chart
          { medals: 25 },
          { medals: 15 },
          { medals: 21 },
          { medals: 42 },
          { medals: 47 },
          { medals: 21 },
          { medals: 24 },
        ],
        'China': [{},
          { medals: 10 },
          { medals: 10 },
          { medals: 25 },
          { medals: 40 },
          { medals: 32 },
          { medals: 12 },
          { medals: 21 },
        ]
      })

      // top, bottom, left, right
      .margin(50,60,120,40)  

      .xAxis({
        range: [1999,2006],
        scale: 1,
        // optional settings
        label: "Years",
        labelBelow: true,
        yPos: 0,
        tickLength: -3,
        tickCentered: true,
        tickLabelCentered: true,
        tickLabels: [], // can be func which receives each label, like `label => {...}`
      })

      .yAxis({
        range: [0,16],
        scale: 1,
        // optional settings
        label: "Gold medals",
        labelLeft: true,
        xPos: 0,
        tickLength: -3,
        tickCentered: false,
        tickLabels: [], // can be func which receives each label, like `label => {...}`
      })

      .drawEach((country, key, i) => {
        // Now we can work with some "decorated" chart data, ${country}.
        // Use your top-level data here - to draw a legend, for example..

        country.forEach(data => {
          // Note, ${data} has .bar(), .circle(), and .line() methods added,
          // which try to draw "ready-made" shapes, in the right place.

          // You should only define the attrs you want "joined" to your
          // data - and don't override any others.
        data.bar({
          height: data.medals,
          stacked: false,
          padding: 24,
          style:{ fill: colors[i] },
        });
        data.circle({
          cy:     data.medals,
          radius: data.medals*2,
          start: 0,
          end: 360,
          rotate: 0,
          style: { fill: colors[i+2], lineWidth: 5, stroke: 'red' },
        });
        data.pie({
          slice: data.medals,
          style: { fill: colors[n] },
        });
        data.arc({
          slice: data.medals,
          radius: 80,
          innerRadius: 40,
          style: { fill: colors[n] },
        });
        data.line({
          py: data.medals,
          stacked: true,
          style: {
            fill: colors[i],
            stroke: colors[i],
            lineWidth: 0,
          },
        });

    });
```

Outputs:

![bar](https://user-images.githubusercontent.com/2726610/140806300-5384dadb-53ca-44cc-9915-bed767a46ed4.png)

..easily flip swap the axes by changing a few lines of code:

![hbar](https://user-images.githubusercontent.com/2726610/140806351-c017eb97-154c-474c-8a5c-cff29a01099b.png)

..same chart, different settings:

![line](https://user-images.githubusercontent.com/2726610/140806745-fad0142b-11c6-44c8-a618-9955fa9b169e.png)

Newer demo:

![charts](https://user-images.githubusercontent.com/2726610/142670839-7e7e5954-529f-4292-8037-3a451031d490.gif)


