### PR TITLE
update: pass in params to xAxis and yAxis as an object

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -110,14 +110,14 @@ function drawAxisLine(ctx, dimensions, whichAxis = 'x', pos, lineWidth = 0.5, st
 function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, tickCentered, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#bbb') {
   const { w, h, x, y } = dimensions,
         max = (whichAxis === 'x') ? w : h,
-        centered = tickCentered ? distanceBetweenTicks/2: 0;
+        centered = tickCentered ? 0 : distanceBetweenTicks/2;
 
   if (tickLength !== 0) {
     ctx.save();
     ctx.lineWidth = lineWidth;
     ctx.strokeStyle = strokeStyle;
 
-    for (let i=0, p=0; i<=max+(tickCentered ? (whichAxis==='y'?-1:0) : distanceBetweenTicks/4); i+=distanceBetweenTicks*scale){
+    for (let i=0, p=0; i<=max+(tickCentered ? distanceBetweenTicks/4 : (whichAxis==='y'?-1:0)); i+=distanceBetweenTicks*scale){
       ctx.beginPath();
       if (whichAxis === 'x'){
         const py = pos < 50 ? y : y-h;
@@ -544,7 +544,7 @@ const extraMethods = {
   //  - direction of rotation
   //  -
 
-  xAxis: function({ range, scale = 1, yPos = 0, tickLength = 5, label = false, labelBelow = true, tickLabelCentered = false, tickCentered = false, tickLabels }) {
+  xAxis: function({ range, scale = 1, yPos = 0, tickLength = 5, label = false, labelBelow = true, tickLabelCentered = false, tickCentered = true, tickLabels }) {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
@@ -586,7 +586,7 @@ const extraMethods = {
     }
   },
 
-  yAxis: function({ range, scale = 1, xPos = 0, tickLength = 5, label = false, labelLeft = true, tickCentered = false, tickLabels }) {
+  yAxis: function({ range, scale = 1, xPos = 0, tickLength = 5, label = false, labelLeft = true, tickCentered = true, tickLabels }) {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),

--- a/src/chart.js
+++ b/src/chart.js
@@ -107,25 +107,26 @@ function drawAxisLine(ctx, dimensions, whichAxis = 'x', pos, lineWidth = 0.5, st
 }
 
 // draws the ticks along the axis, used by xAxis and yAxis
-function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#bbb') {
+function drawAxisTicks(ctx, dimensions, whichAxis = 'x', pos, tickLength, tickCentered, distanceBetweenTicks, scale, lineWidth = 0.5, strokeStyle = '#bbb') {
   const { w, h, x, y } = dimensions,
-        max = (whichAxis === 'x') ? w : h;
+        max = (whichAxis === 'x') ? w : h,
+        centered = tickCentered ? distanceBetweenTicks/2: 0;
 
   if (tickLength !== 0) {
     ctx.save();
     ctx.lineWidth = lineWidth;
     ctx.strokeStyle = strokeStyle;
 
-    for (let i=0, p=0; i<=max; i+=distanceBetweenTicks*scale){
+    for (let i=0, p=0; i<=max+(tickCentered ? (whichAxis==='y'?-1:0) : distanceBetweenTicks/4); i+=distanceBetweenTicks*scale){
       ctx.beginPath();
       if (whichAxis === 'x'){
         const py = pos < 50 ? y : y-h;
-        ctx.moveTo(x+i,py);
-        ctx.lineTo(x+i,py-(tickLength/100*h))
+        ctx.moveTo(x+i+(centered),py);
+        ctx.lineTo(x+i+(centered),py-(tickLength/100*h))
       } else {
         const px = pos < 50 ? x : x+w;
-        ctx.moveTo(px,y-i);
-        ctx.lineTo(px+(tickLength/100*w),y-i);
+        ctx.moveTo(px,y-i-(centered));
+        ctx.lineTo(px+(tickLength/100*w),y-i-(centered));
       }
       ctx.stroke();
       ctx.closePath();
@@ -543,7 +544,7 @@ const extraMethods = {
   //  - direction of rotation
   //  -
 
-  xAxis: function(range, scale = 1, yPos = 0, tickLength = 5, label = false, below = true, centered = false, tickLabels) {
+  xAxis: function({ range, scale = 1, yPos = 0, tickLength = 5, label = false, labelBelow = true, tickLabelCentered = false, tickCentered = false, tickLabels }) {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
@@ -555,7 +556,7 @@ const extraMethods = {
     this._d.xDistance = distanceBetweenTicks;
     this._d.xLabels = [];
 
-    drawAxisTicks(this, { w, h, x, y }, 'x', yPos, yPos <= 50 ? tickLength : -tickLength, distanceBetweenTicks, scale);
+    drawAxisTicks(this, { w, h, x, y }, 'x', yPos, yPos <= 50 ? tickLength : -tickLength, tickCentered, distanceBetweenTicks, scale);
     drawAxisLine(this,  { w, h, x, y }, 'x', yPos);
 
     for (let i=0, p=0; i<=(w+distanceBetweenTicks/2); i+=distanceBetweenTicks*scale) {
@@ -564,8 +565,8 @@ const extraMethods = {
 
       const py = yPos <= 50 ? (y+16+8)-(h/100*yPos) : y-(h/100*yPos)-16;
       const px = flippedAxis
-        ? centered ? x+w-i-(labelLength/2) : x+w-i
-        : centered ? x+i-(labelLength/2) : x+i;
+        ? tickLabelCentered ? x+w-i-(labelLength/2) : x+w-i
+        : tickLabelCentered ? x+i-(labelLength/2) : x+i;
 
       this.fillText(tickLabel, px, py);
       p++;
@@ -578,14 +579,14 @@ const extraMethods = {
       //x
       (x+w/2)-(labelLength/2),
       //y
-      below
+      labelBelow
         ? y+(16*3)
         : y-h-(16*2)-8
       );
     }
   },
 
-  yAxis: function(range, scale = 1, xPos = 0, tickLength = 5, label = false, leftLabel = true, tickLabels) {
+  yAxis: function({ range, scale = 1, xPos = 0, tickLength = 5, label = false, labelLeft = true, tickCentered = false, tickLabels }) {
     const { w, h, x, y } = getDimensions(this),
           flippedAxis = range[0] > range[1],
           theRange = getRange(range),
@@ -598,7 +599,7 @@ const extraMethods = {
     this._d.yDistance = distanceBetweenTicks;
     this._d.yLabels = [];
 
-    drawAxisTicks(this, { w, h, x, y }, 'y', xPos, xPos <= 50 ? tickLength : -tickLength, distanceBetweenTicks, scale);
+    drawAxisTicks(this, { w, h, x, y }, 'y', xPos, xPos <= 50 ? tickLength : -tickLength, tickCentered, distanceBetweenTicks, scale);
     drawAxisLine(this,  { w, h, x, y }, 'y', xPos);
 
     for (let i=0, p=0; i<=h; i+=distanceBetweenTicks*scale){
@@ -621,7 +622,7 @@ const extraMethods = {
         // text
         label,
         // x
-        leftLabel
+        labelLeft
           ? x-(`${label}`.length*6)-32-(maxLabelWidth*6)
           : xPos <= 50 ? x+w+16 : x+w+32+(maxLabelWidth*6),
         // y


### PR DESCRIPTION
This makes it easier/clearer to set up axes for a few reasons:

- define the props by name
- define props in any order
- leave out any props you dont need to set
- easier to read, clearer/more explicit
- easier to extend

..on that last note, a "tickCentre" option has
been added, so you can have the ticks centered
next to the label, or split around it.

Usage 

```js
    .xAxis({
      range: [1999,2006],
      scale: 1,
      label: "Years",
      labelBelow: true,
      yPos: 0,
      tickLength: -3,
      tickCentered: true,
      tickLabelCentered: true,
      tickLabels: [],
    })

    .yAxis({
      range: [0,16],
      scale: 1,
      label: "Gold medals",
      labelLeft: true,
      xPos: 0,
      tickLength: -3,
      tickCentered: false,
      tickLabels: [],
    })
```