### PR TITLE
Feature/canvas object event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1574,8 +1574,13 @@ Features:
 
 - interactive canvas:
   - create interactive "canvas objects" using very simple API
-  - re-style the "canvas objects" on `hover`, `click` and `drag`
-- extra drawing methods: 
+  - update "canvas objects" on `hover`, `click`, `drag` and `release`
+  - easily style your "canvas objects"
+  - define your own, custom "canvas objects" to interact with
+  - flexible syntax and extendable API
+- a simple camera:
+  - pan, scale, rotate
+- extra drawing methods built-in: 
   - arrows and arced arrows
   - cardinals splines (smooth curves, with segments and optional points) 
   - circles & ellipses 
@@ -1588,18 +1593,15 @@ Features:
   - stars
   - triangles
   - more..
-- a simple camera:
-  - pan, scale, rotate
 - chainable API:
   - all methods are chainable unless they return something (see regular canvas API)
 - maths helper functions:
-  - convert between radians/degrees, get distances, etc
+  - convert between radians/degrees, get distances, angles, lerp, etc
 - save to image and video:
   - embed SVG as code, Element or file with `ctx.drawImg()`, which handles caching for you
   - save canvas as an image with `ctx.canvas.image.saveAs('filename.png')`
   - record canvas to video with `ctx.canvas.video.record()`
   - save the video with `ctx.canvas.video.saveAs('filename.webm')`
-- less than 5kb, minified & gzipped
 
 Note: 
 
@@ -1723,7 +1725,7 @@ ctx.canvas.addEventListener('mousedown', event => {
 }, false);
 ```
 
-See [examples/usage-Ctx-interactive.html](examples/usage-Ctx-interactive.html) for more information.
+There's loads more features - see [examples/usage-Ctx-interactive.html](examples/usage-Ctx-interactive.html) for more information.
 
 
 ### Additional methods provided by `Ctx`

--- a/examples/usage-Ctx-interactive.html
+++ b/examples/usage-Ctx-interactive.html
@@ -40,8 +40,7 @@ const Foo = new Component({ frame: 0, x: 280, y: 100 });
 let context,
     // objects used by our interactive canvas
     filledRect,
-    mouse,
-    myMouse,
+    myMickey,
     myStar,
     myStarFill,
     myStarStroke,
@@ -59,30 +58,30 @@ Foo.view = (props, ctx) => {
     // create interactive objects, using `ctx.create`
     filledRect = ctx.create.rect(30, 30, 200, 200);
     myStar = ctx.create.star(myStarX, myStarY, 50, 5, 0);
-
-    // extend the ctx.create API with our a drawing function:
+    // extend the ctx.create API with a new drawing function:
     // * all 3 circles will be seen as _one_ "canvas object"
     ctx.create('mickey', function(x, y, r) {
       [ctx, ctx.shadowCtx ].forEach(c => {
-        c.fillCircle(x,y,r/2, 360, false);         // head
-        c.fillCircle(x-r/2,y-y/2,r/3, 360, false); // ear 1
-        c.fillCircle(x+r/2,y-y/2,r/3, 360, false); // ear 2
+        c.beginPath();
+        c.fillCircle(x,y,r/2, 360, true);         // head
+        c.fillCircle(x-r/2,y-r/2,r/3, 360, true); // ear 1
+        c.fillCircle(x+r/2,y-r/2,r/3, 360, true); // ear 2
+        c.closePath();
       });
     });
     // now lets use it
-    myMouse = ctx.create.mickey(100, 100, 80);
+    myMickey = ctx.create.mickey(100, 100, 80);
   }
 
   ctx.clear()  // using `clear(true)` will clear transforms too
 
-
-
-  myMouse.update(30+frame/4, 100, 100);
-  myMouse.onClick(props => console.log('mickey CLICK!'));
-  myMouse.onHover(props => console.log('mickey HOVER!'));
-  myMouse.draw({
-    strokeStyle: myMouse.click ? 'red' : 'black',
-    fillStyle: myMouse.hover ? 'lightgreen' : 'black',
+  myMickey.onClick(props => console.log('mickey CLICK!'));
+  myMickey.onHover(props => console.log('mickey HOVER!'));
+  if (myMickey.drag) {
+    myMickey.update(ctx.mouse.x, ctx.mouse.y, 100);
+  }
+  myMickey.draw({
+    fillStyle: myMickey.hover ? '#c0c' : '#333',
   });
 
 
@@ -127,7 +126,7 @@ Foo.view = (props, ctx) => {
     lineWidth: 5,
   });
 
-  if (frame > 250) return;
+  if (frame > 1000) return;
 
   // re-render in a loop
   Foo.setState({

--- a/examples/usage-Ctx-interactive.html
+++ b/examples/usage-Ctx-interactive.html
@@ -81,6 +81,21 @@ Foo.view = (props, ctx) => {
   //
   ctx.clear()  // using `clear(true)` will clear transforms too
 
+  // update a shape, but dont redraw it
+  myRect.update({ w: 160 });
+  // lets use `adjust`: adds the given values to its current properties
+  myRect.adjust({ x: 0.25, y: 0, w: 0, h: -0.15 });
+  // which is the same as:
+  myRect.adjust({ x: 0.25, h: -0.15 });
+  // now render, optionally pass in some styles if needed/desired
+  myRect.draw({
+    fillStyle: myRect.hover ? 'yellow' : 'lightblue',
+    strokeStyle: myRect.hover ? 'red' : 'blue',
+    lineWidth: 3,
+  });
+
+  // ...
+
   myMickey.on('click', props => console.log('mickey CLICK!'));
   myMickey.on('hover', props => console.log('mickey HOVER!'));
 
@@ -89,36 +104,25 @@ Foo.view = (props, ctx) => {
 
   if (myMickey.drag) {
     // update the props
-    //myMickey.update({ x: ctx.mouse.x, y: ctx.mouse.y });
-    // ...or set using the *named* props (only works if we defined props as an object)
+    myMickey.update({ x: ctx.mouse.x, y: ctx.mouse.y });
+    // ...or set using the *named* props (only works if we defined the props as an object)
     myMickey.x = ctx.mouse.x;
     myMickey.y = ctx.mouse.y;
   }
 
   // you can also update props and styles using functions
-  if (myMickey.hover) {
+  if (myMickey.click) {
     myMickey.r = r => (r < 100) ? r + 2 : r; // grow the radius up to 100
   } else {
     myMickey.r = r => (r >  80) ? r - 2 : r; // shrink radius down to 80
   }
 
-  // look out - any styles passed into draw() override all others
+  // careful, any styles passed into draw() override all others
   myMickey.draw({
     //fillStyle: myMickey.hover ? '#c0c' : '#333',
   });
 
   // ...
-
-  // lets use `adjust`: adds the given values to its current properties
-  myRect.adjust({ x: 0.25, y: 0, w: 0, h: 0 });
-  // which is the same as:
-  myRect.adjust({ x: 0.25 });
-
-  myRect.draw({
-    fillStyle: myRect.hover ? 'yellow' : 'lightblue',
-    strokeStyle: myRect.hover ? 'red' : 'blue',
-    lineWidth: 3,
-  });
 
   if (myStar.drag) {
     // now update it
@@ -134,7 +138,7 @@ Foo.view = (props, ctx) => {
     //myStar.y =  ctx.lerp(myStar.y, ctx.mouse.y, 0.01);
   }
 
-  // or use event handlers  -  onHover, onClick, onDrag
+  // or use event handlers
   myStar.on('hover', d => {
     console.log('myStar hover', d.shape);
   });

--- a/examples/usage-Ctx-interactive.html
+++ b/examples/usage-Ctx-interactive.html
@@ -78,7 +78,7 @@ Foo.view = (props, ctx) => {
   myMickey.onClick(props => console.log('mickey CLICK!'));
   myMickey.onHover(props => console.log('mickey HOVER!'));
   if (myMickey.drag) {
-    myMickey.update(ctx.mouse.x, ctx.mouse.y, 100);
+    myMickey.update(ctx.mouse.x, ctx.mouse.y, 80);
   }
   myMickey.draw({
     fillStyle: myMickey.hover ? '#c0c' : '#333',

--- a/examples/usage-Ctx-interactive.html
+++ b/examples/usage-Ctx-interactive.html
@@ -39,13 +39,9 @@ const Foo = new Component({ frame: 0, x: 280, y: 100 });
 // a reference to Foo.ctx, so we can access it outside the components view
 let context,
     // objects used by our interactive canvas
-    filledRect,
+    myRect,
     myMickey,
-    myStar,
-    myStarFill,
-    myStarStroke,
-    myStarX = 200,
-    myStarY = 400;
+    myStar;
 
 // define a "view", that draws to the components canvas
 Foo.view = (props, ctx) => {
@@ -55,11 +51,14 @@ Foo.view = (props, ctx) => {
     ctx.size(640, 480);
     // keep references for outside the Foo component
     context = ctx;
-    // create interactive objects, using `ctx.create`
-    filledRect = ctx.create.rect(30, 30, 200, 200);
-    myStar = ctx.create.star(myStarX, myStarY, 50, 5, 0);
-    // extend the ctx.create API with a new drawing function:
-    // * all 3 circles will be seen as _one_ "canvas object"
+
+    // Create interactive objects, using `ctx.create`
+    //myStar = ctx.create.star(100, 100, 50, 5, 0);
+    myStar = ctx.create.star({ x: 200, y: 400, radius: 50, points: 5, angle: 0 });
+    myRect = ctx.create.rect({ x: 30, y: 30, w: 200, h: 200 });
+
+    // Lets define a *new*, custom "interactive canvas object":
+    //  ...all 3 circles will be seen as _one_ object
     ctx.create('mickey', function(x, y, r) {
       [ctx, ctx.shadowCtx ].forEach(c => {
         c.beginPath();
@@ -69,62 +68,80 @@ Foo.view = (props, ctx) => {
         c.closePath();
       });
     });
-    // now lets use it
-    myMickey = ctx.create.mickey(100, 100, 80);
+    myMickey = ctx.create.mickey({ x: 100, y: 100, r: 80 });
+
+    console.log('myStar', myStar);
+    console.log('myRect', myRect);
+    console.log('myMickey', myMickey);
   }
 
   ctx.clear()  // using `clear(true)` will clear transforms too
 
-  myMickey.onClick(props => console.log('mickey CLICK!'));
-  myMickey.onHover(props => console.log('mickey HOVER!'));
+  myMickey.on('click', props => console.log('mickey CLICK!'));
+  myMickey.on('hover', props => console.log('mickey HOVER!'));
+
   if (myMickey.drag) {
-    myMickey.update(ctx.mouse.x, ctx.mouse.y, 80);
+    // update the props
+    //myMickey.update({ x: ctx.mouse.x, y: ctx.mouse.y });
+    // ...or set using the *named* props (only works if we defined props as an object)
+    myMickey.x = ctx.mouse.x;
+    myMickey.y = ctx.mouse.y;
   }
+
+  // any ctx style props can be added to a "canvas object"
+  myMickey.fillStyle = myMickey.hover ? 'lightgreen' : 'cyan';
+
+  // any styles passed into draw() override all others
   myMickey.draw({
     fillStyle: myMickey.hover ? '#c0c' : '#333',
   });
 
+  // lets use `adjust`: adds the given values to its current properties
+  myRect.adjust({ x: 0.25, y: 0, w: 0, h: 0 });
+  // which is the same as:
+  myRect.adjust({ x: 0.25 });
 
-  filledRect.update(30+(frame/2), 30, 200, 200);
-
-  filledRect.draw({
-    fillStyle: filledRect.hover ? 'yellow' : 'lightblue',
-    strokeStyle: filledRect.hover ? 'red' : 'blue',
+  myRect.draw({
+    fillStyle: myRect.hover ? 'yellow' : 'lightblue',
+    strokeStyle: myRect.hover ? 'red' : 'blue',
     lineWidth: 3,
   });
 
-  myStarFill = myStar.click ? 'lightgreen' : 'yellow';
-  myStarStroke = myStar.hover ? 'red' : 'orange';
-
   if (myStar.drag) {
-    myStarX = ctx.mouse.x;
-    myStarY = ctx.mouse.y + myStar.props[2]/4;
-    myStar.update(myStarX, myStarY, 50, 5, 0);
+    // now update it
+    myStar.update({ x: ctx.mouse.x, y: ctx.mouse.y });
+    // or simply (same as above)
+    myStar.x = ctx.mouse.x;
+    myStar.y = ctx.mouse.y;
+    // ...optionally interpolate the values
+    //myStar.x += (ctx.mouse.x - myStar.x) * 0.1;
+    //myStar.y += (ctx.mouse.y - myStar.y) * 0.1;
+    // ..which is the same as
+    //myStar.x =  ctx.lerp(myStar.x, ctx.mouse.x, 0.01);
+    //myStar.y =  ctx.lerp(myStar.y, ctx.mouse.y, 0.01);
   }
 
   // or use event handlers  -  onHover, onClick, onDrag
-  myStar.onHover(d => {
+  myStar.on('hover', d => {
     console.log('myStar hover', d.shape);
   });
-  myStar.onClick(d => {
+  myStar.on('click', d => {
     console.log('myStar clicked', d.id);
   });
-  myStar.onRelease(d => {
+  myStar.on('release', d => {
     console.log('myStar released', d.id);
   });
-  myStar.onDrag(d => {
+  myStar.on('drag', d => {
     console.log('myStar dragging', d.props);
-    // note that using `myStar.drag` (as above) works better
-    //myStarX = ctx.mouse.x;
-    //myStarY = ctx.mouse.y + d.props[2]/4;
-    //myStar.update(myStarX, myStarY, 50, 5, 0);
+    // note that using `myStar.drag` (as above) works better than `onDrag()`
+    //myStar.update({ x: ctx.mouse.x, y: ctx.mouse.y });
   });
 
-  myStar.draw({
-    fillStyle: myStarFill,
-    strokeStyle: myStarStroke,
-    lineWidth: 5,
-  });
+  myStar.lineWidth = 5;
+  myStar.strokeStyle = myStar.hover ? 'crimson'    : 'orange';
+  myStar.fillStyle   = myStar.click ? 'lightgreen' : 'yellow';
+
+  myStar.draw();
 
   if (frame > 1000) return;
 
@@ -153,15 +170,11 @@ setTimeout(() => {
       tooltip.innerHTML = `
         <br>  Mouse  x,y: ${event.offsetX}, ${event.offsetY}
         <br>   Object id: ${context.hoverObj.id}
-        <br>Object props: ${context.hoverObj.props}
-        <br>Object drag: ${context.hoverObj.drag}
+        <br>Object props: ${typeof context.hoverObj.props === 'object' ? JSON.stringify(context.hoverObj.props) : context.hoverObj.props}
+        <br>Object drag: ${!!context.hoverObj.drag}
       `;
     }
-    //if (myStar && myStar.drag) {
-    //  myStarX = context.mouse.x;
-    //  myStarY = context.mouse.y + myStar.props[2]/4;
-    //  myStar.update(myStarX, myStarY, 50, 5, 0);
-    //}
+    // you can also check `myShape.drag` here
 
   }, false);
 

--- a/examples/usage-Ctx-interactive.html
+++ b/examples/usage-Ctx-interactive.html
@@ -40,6 +40,8 @@ const Foo = new Component({ frame: 0, x: 280, y: 100 });
 let context,
     // objects used by our interactive canvas
     filledRect,
+    mouse,
+    myMouse,
     myStar,
     myStarFill,
     myStarStroke,
@@ -57,32 +59,79 @@ Foo.view = (props, ctx) => {
     // create interactive objects, using `ctx.create`
     filledRect = ctx.create.rect(30, 30, 200, 200);
     myStar = ctx.create.star(myStarX, myStarY, 50, 5, 0);
+
+    // extend the ctx.create API with our a drawing function:
+    // * all 3 circles will be seen as _one_ "canvas object"
+    ctx.create('mickey', function(x, y, r) {
+      [ctx, ctx.shadowCtx ].forEach(c => {
+        c.fillCircle(x,y,r/2, 360, false);         // head
+        c.fillCircle(x-r/2,y-y/2,r/3, 360, false); // ear 1
+        c.fillCircle(x+r/2,y-y/2,r/3, 360, false); // ear 2
+      });
+    });
+    // now lets use it
+    myMouse = ctx.create.mickey(100, 100, 80);
   }
 
   ctx.clear()  // using `clear(true)` will clear transforms too
 
-  filledRect.update(30+frame, 30, 200, 200);
+
+
+  myMouse.update(30+frame/4, 100, 100);
+  myMouse.onClick(props => console.log('mickey CLICK!'));
+  myMouse.onHover(props => console.log('mickey HOVER!'));
+  myMouse.draw({
+    strokeStyle: myMouse.click ? 'red' : 'black',
+    fillStyle: myMouse.hover ? 'lightgreen' : 'black',
+  });
+
+
+  filledRect.update(30+(frame/2), 30, 200, 200);
 
   filledRect.draw({
-    fillStyle: filledRect.hover ? 'lightgreen' : 'lightblue',
+    fillStyle: filledRect.hover ? 'yellow' : 'lightblue',
     strokeStyle: filledRect.hover ? 'red' : 'blue',
     lineWidth: 3,
   });
 
-
   myStarFill = myStar.click ? 'lightgreen' : 'yellow';
   myStarStroke = myStar.hover ? 'red' : 'orange';
+
   if (myStar.drag) {
-    myStarX = ctx.mousePos.x;
-    myStarY = ctx.mousePos.y + myStar.props[2]/4;
+    myStarX = ctx.mouse.x;
+    myStarY = ctx.mouse.y + myStar.props[2]/4;
+    myStar.update(myStarX, myStarY, 50, 5, 0);
   }
 
-  myStar.update(myStarX, myStarY, 50, 5, 0);
+  // or use event handlers  -  onHover, onClick, onDrag
+  myStar.onHover(d => {
+    console.log('myStar hover', d.shape);
+  });
+  myStar.onClick(d => {
+    console.log('myStar clicked', d.id);
+  });
+  myStar.onRelease(d => {
+    console.log('myStar released', d.id);
+  });
+  myStar.onDrag(d => {
+    console.log('myStar dragging', d.props);
+    // note that using `myStar.drag` (as above) works better
+    //myStarX = ctx.mouse.x;
+    //myStarY = ctx.mouse.y + d.props[2]/4;
+    //myStar.update(myStarX, myStarY, 50, 5, 0);
+  });
 
   myStar.draw({
     fillStyle: myStarFill,
     strokeStyle: myStarStroke,
     lineWidth: 5,
+  });
+
+  if (frame > 250) return;
+
+  // re-render in a loop
+  Foo.setState({
+    frame: frame + 1,
   });
 };
 
@@ -109,6 +158,12 @@ setTimeout(() => {
         <br>Object drag: ${context.hoverObj.drag}
       `;
     }
+    //if (myStar && myStar.drag) {
+    //  myStarX = context.mouse.x;
+    //  myStarY = context.mouse.y + myStar.props[2]/4;
+    //  myStar.update(myStarX, myStarY, 50, 5, 0);
+    //}
+
   }, false);
 
   context.canvas.addEventListener('mousedown', event => {
@@ -120,11 +175,13 @@ setTimeout(() => {
 
 
 // move stuff around a bit in an animated loop
-const loop = setInterval(() => {
-  Foo.setState({
-    frame: Foo.state.frame + 1,
-  });
-}, 1000 / 60);
+//const loop = setInterval(() => {
+//  if (Foo.state.frame < 500) {
+//    Foo.setState({
+//      frame: Foo.state.frame + 1,
+//    });
+//  }
+//}, 1000 / 30);
 
 </script>
 </body>

--- a/examples/usage-Ctx-interactive.html
+++ b/examples/usage-Ctx-interactive.html
@@ -95,13 +95,11 @@ Foo.view = (props, ctx) => {
     myMickey.y = ctx.mouse.y;
   }
 
+  // you can also update props and styles using functions
   if (myMickey.hover) {
-    // you can also update props and styles using functions
-    myMickey.fillStyle = prop => {
-      const xynum  = myMickey.x - myMickey.y,
-            hexnum = +prop.replace('#', '0x');
-      return ctx.int2hex(hexnum/2 - xynum*2);
-    }
+    myMickey.r = r => (r < 100) ? r + 2 : r; // grow the radius up to 100
+  } else {
+    myMickey.r = r => (r >  80) ? r - 2 : r; // shrink radius down to 80
   }
 
   // look out - any styles passed into draw() override all others

--- a/examples/usage-Ctx-interactive.html
+++ b/examples/usage-Ctx-interactive.html
@@ -57,7 +57,7 @@ Foo.view = (props, ctx) => {
     myStar = ctx.create.star({ x: 200, y: 400, radius: 50, points: 5, angle: 0 });
     myRect = ctx.create.rect({ x: 30, y: 30, w: 200, h: 200 });
 
-    // Lets define a *new*, custom "interactive canvas object":
+    // Lets define a new, _custom_ "interactive canvas object":
     //  ...all 3 circles will be seen as _one_ object
     ctx.create('mickey', function(x, y, r) {
       [ctx, ctx.shadowCtx ].forEach(c => {
@@ -70,15 +70,22 @@ Foo.view = (props, ctx) => {
     });
     myMickey = ctx.create.mickey({ x: 100, y: 100, r: 80 });
 
+    // debug
     console.log('myStar', myStar);
     console.log('myRect', myRect);
     console.log('myMickey', myMickey);
   }
 
+  //
+  // Let's start drawing in a loop from here
+  //
   ctx.clear()  // using `clear(true)` will clear transforms too
 
   myMickey.on('click', props => console.log('mickey CLICK!'));
   myMickey.on('hover', props => console.log('mickey HOVER!'));
+
+  // any ctx style props can be added to a "canvas object"
+  myMickey.fillStyle = myMickey.hover ? 'lightgreen' : 'cyan';
 
   if (myMickey.drag) {
     // update the props
@@ -88,13 +95,21 @@ Foo.view = (props, ctx) => {
     myMickey.y = ctx.mouse.y;
   }
 
-  // any ctx style props can be added to a "canvas object"
-  myMickey.fillStyle = myMickey.hover ? 'lightgreen' : 'cyan';
+  if (myMickey.hover) {
+    // you can also update props and styles using functions
+    myMickey.fillStyle = prop => {
+      const xynum  = myMickey.x - myMickey.y,
+            hexnum = +prop.replace('#', '0x');
+      return ctx.int2hex(hexnum/2 - xynum*2);
+    }
+  }
 
-  // any styles passed into draw() override all others
+  // look out - any styles passed into draw() override all others
   myMickey.draw({
-    fillStyle: myMickey.hover ? '#c0c' : '#333',
+    //fillStyle: myMickey.hover ? '#c0c' : '#333',
   });
+
+  // ...
 
   // lets use `adjust`: adds the given values to its current properties
   myRect.adjust({ x: 0.25, y: 0, w: 0, h: 0 });

--- a/src/ctx.js
+++ b/src/ctx.js
@@ -963,7 +963,7 @@ const Ctx = function(origCtx, c) {
   // create an offscreen canvas, so we can:
   // * draw things to it, always with a unique color
   // * lookup a color to know which object/shape it refers to
-  document.body.append(shadowCanvas);
+  //document.body.append(shadowCanvas);
   shadowCanvas.height = this.canvas.height;
   shadowCanvas.width = this.canvas.width;
   shadowCanvas.style.height = this.canvas.style.height;

--- a/src/ctx.js
+++ b/src/ctx.js
@@ -224,7 +224,7 @@ const DEG2RAD = PI / 180;
 
      function getMousePos(event) {
         var rect = ctx.canvas.getBoundingClientRect();
-        ctx.mousePos = {x:(event.clientX-rect.left)/ctx.canvas.scale, y:(event.clientY-rect.top)/ctx.canvas.scale};
+        ctx.mouse = {x:(event.clientX-rect.left)/ctx.canvas.scale, y:(event.clientY-rect.top)/ctx.canvas.scale};
       }
 
 - node graph
@@ -963,7 +963,7 @@ const Ctx = function(origCtx, c) {
   // create an offscreen canvas, so we can:
   // * draw things to it, always with a unique color
   // * lookup a color to know which object/shape it refers to
-  //document.body.append(shadowCanvas);
+  document.body.append(shadowCanvas);
   shadowCanvas.height = this.canvas.height;
   shadowCanvas.width = this.canvas.width;
   shadowCanvas.style.height = this.canvas.style.height;
@@ -1103,49 +1103,70 @@ const Ctx = function(origCtx, c) {
 
   // interactive canvas
 
-  this.create = {}; // will be ctx.create.rect(), ctx.create.circle(), etc
+  const generateCanvasObject = (fnName, props, drawFn) => {
+	  // Inside obj, `this` refers to the extended context
+	  const obj = {
+	    shape: fnName,
+	    props: [...props],
+	    update: (...props) => obj.props = [...props],
+	    draw: (styles) => {
+	      const props = obj.props;
+	      if (styles) {
+	        for (let [key, value] of Object.entries(styles)) {
+	          this[key](value);
+	        }
+	      }
+	      if (typeof this[fnName] === 'function') {
+	        this.beginPath();
+	        this.save();
+	        this[fnName](...props);
+          this.fill();
+          this.stroke();
+          this.closePath();
+  	      this.restore();
+	      } else {
+          drawFn(...props);
+	      }
+	      // draw `obj` to an off-screen canvas, using the unique color
+	      this.shadowCtx.beginPath();
+	      this.shadowCtx.fillStyle = obj.id;
+	      this.shadowCtx[fnName](...props);
+	      this.shadowCtx.fill();
+	    },
+	    // event handlers
+	    onHover: fn => obj.hoverHandler = fn,
+	    onClick: fn => obj.clickHandler = fn,
+	    onRelease: fn => obj.releaseHandler = fn,
+	    onDrag: fn => obj.dragHandler = fn,
+	  };
+
+	  // get the unique color as an id
+	  obj.id = this.register(obj);
+	  if (!obj.id) return Error('registry is full')
+
+	  // draw on regular and shadow canvas
+	  obj.draw(...props)
+
+	  return obj;
+  }
+
+  this.create = (fnName, fn) => {
+    // add this method to shadow canvas
+    this.shadowCtx[fnName] = (...props) => fn.apply(this.shadowCtx, [...props]);
+    // add the new method to the `ctx.create` API
+    this.create[fnName] = (...props) => generateCanvasObject(fnName, props, fn);
+    return this.create[fnName];
+  }
 
   // Add methods to the `ctx.create` object - one for each
   // supported Ctx drawing method
+
   [...ctxMethods, ...extraMethodNames].forEach(fnName => {
   	// Create the ctx.create.rect() (etc) methods
   	// - each method:
   	//    - returns an object with methods .update(props) and .draw(style)
   	//    - registers the object on a shadow canvas with a unique color (id)
-  	this.create[fnName] = (...props) => {
-  	  // Inside obj, `this` refers to the extended context
-  	  const obj = {
-  	    props: [...props],
-  	    update: (...props) => obj.props = [...props],
-  	    draw: (styles) => {
-  	      const props = obj.props;
-  	      this.save();
-  	      if (styles) {
-  	        for (let [key, value] of Object.entries(styles)) {
-  	          this[key](value);
-  	        }
-  	      }
-  	      this[fnName](...props);
-  	      this.fill();
-  	      this.stroke();
-  	      this.restore();
-  	      // draw `obj` to an off-screen canvas, using the unique color
-  	      this.shadowCtx.beginPath();
-  	      this.shadowCtx.fillStyle = obj.id;
-  	      this.shadowCtx[fnName](...props);
-  	      this.shadowCtx.fill();
-  	    },
-  	  };
-
-  	  // get the unique color as an id
-  	  obj.id = this.register(obj);
-  	  if (!obj.id) return Error('registry is full')
-
-  	  // draw on regular and shadow canvas
-  	  obj.draw(...props)
-
-  	  return obj;
-  	};
+  	this.create[fnName] = (...props) => generateCanvasObject(fnName, props);
   });
 
   // unique color for every item drawn to off-screen canvas:
@@ -1154,20 +1175,26 @@ const Ctx = function(origCtx, c) {
   const checksum = (n, csBits) => (n * ENTROPY) % Math.pow(2, csBits);
   const int2HexColor = num => `#${Math.min(num, Math.pow(2, 24)).toString(16).padStart(6, '0')}`;
   const rgb2Int = (r, g, b) => (r << 16) + (g << 8) + b;
+  const hex2rgb = (hex) => {
+    const rgb = parseInt(hex.replace('#',''), 16),
+          r = (rgb >> 16) & 0xFF,
+          g = (rgb >> 8) & 0xFF,
+          b = rgb & 0xFF;
+    return [r,g,b];
+  };
   const csBits = 6;
-
   // remember all canvas objects in this registry:
-  const registry = ['__reserved_for_background__'];
+  this.registry = ['__reserved_for_background__'];
 
   // add obj to registry, returns the objects unique color:
   this.register = (obj) => {
-    if (registry.length >= Math.pow(2, 24 - csBits)) { // color has 24 bits (-checksum)
+    if (this.registry.length >= Math.pow(2, 24 - csBits)) { // color has 24 bits (-checksum)
       return null; // Registry is full
     }
-    const idx = registry.length;
+    const idx = this.registry.length;
     const cs = checksum(idx, csBits);
     const color = int2HexColor(idx + (cs << (24 - csBits)));
-    registry.push(obj);
+    this.registry.push(obj);
     return color;
   };
 
@@ -1186,16 +1213,19 @@ const Ctx = function(origCtx, c) {
     if (!n) return { id: 0 }; // 0 index is reserved for background
     const idx = n & (Math.pow(2, 24 - csBits) - 1); // registry index
     const cs = (n >> (24 - csBits)) & (Math.pow(2, csBits) - 1); // extract bits reserved for checksum
-    if (checksum(idx, csBits) !== cs || idx >= registry.length) return null; // failed checksum or registry out of bounds
-    return registry[idx];
+    if (checksum(idx, csBits) !== cs || idx >= this.registry.length) return null; // failed checksum or registry out of bounds
+    return this.registry[idx];
   };
 
   // get object at x,y
   this.objectAt = (x,y) => this.lookup(this.pxColor(x,y));
 
+  // get object from an id (unique color)
+  this.getObject = (id) => this.lookup(hex2rgb(id));
+
   // event listeners
 
-  this.mousePos = {
+  this.mouse = {
     x: 0,
     y: 0,
     dragStart: null, // will be an object:  { x, y }
@@ -1205,20 +1235,26 @@ const Ctx = function(origCtx, c) {
 
   // define event listeners, set vars we can access in our canvas drawing code
   this.canvas.addEventListener('mousemove', e => {
-    this.mousePos.x = e.offsetX;
-    this.mousePos.y = e.offsetY;
+    const m = this.mouse;
+    m.x = e.offsetX;
+    m.y = e.offsetY;
     if (this.hoverObj) this.hoverObj.hover = false;
     this.hoverObj = this.objectAt(e.offsetX, e.offsetY);
-    if (this.hoverObj && this.hoverObj.id) {
-      this.hoverObj.hover = true;
+    const o = this.hoverObj;
+    if (o && o.id) {
+      o.hover = true;
       // drag and drop
-      const { dragStart, dragEnd } = this.mousePos;
-      this.hoverObj.drag = false;
+      const { dragStart, dragEnd } = m;
+      o.drag = false;
       if (dragStart && !dragEnd) {
-        if (dragStart.x != e.offsetX || dragStart.y != e.offsetY) {
-          // we started dragging, and we moved away from the original x,y location
-          this.hoverObj.drag = true;
-        }
+        // we started dragging, and we moved away from the original x,y location
+        // run event handler
+        if (o.onDrag && o.dragHandler) o.dragHandler(o);
+        o.drag = true;
+      }
+      // run event handler
+      if (o.onHover && o.hoverHandler && !o.drag) {
+        o.hoverHandler(o);
       }
     } else {
       this.hoverObj = null;
@@ -1227,21 +1263,31 @@ const Ctx = function(origCtx, c) {
 
   this.canvas.addEventListener('mousedown', e => {
     this.hoverObj = this.objectAt(e.offsetX, e.offsetY);
-    if (this.hoverObj && this.hoverObj.id) this.hoverObj.click = true;
+    const m = this.mouse,
+          o = this.hoverObj;
+    if (o && o.id) {
+      o.click = true;
+      // run event handler
+      if (o.onClick && o.clickHandler) o.clickHandler(o);
+    }
     // drag n drop
-    this.mousePos.dragEnd = null;
+    m.dragEnd = null;
     // if we didnt start dragging yet, start dragging
-    if (!this.mousePos.dragStart) this.mousePos.dragStart = { x: e.offsetX, y: e.offsetY };
+    if (!m.dragStart) m.dragStart = { x: e.offsetX, y: e.offsetY };
   }, false);
 
   this.canvas.addEventListener('mouseup', e => {
     this.hoverObj = this.objectAt(e.offsetX, e.offsetY);
-    if (this.hoverObj && this.hoverObj.id) {
-      this.hoverObj.click = false;
-      this.hoverObj.drag = false;
+    const m = this.mouse,
+          o = this.hoverObj;
+    if (o && o.id) {
+      o.click = false;
+      o.drag = false;
+      // run event handler
+      if (o.onRelease && o.releaseHandler) o.releaseHandler(o);
     }
     // drag n drop: if we were dragging the cursor, end dragging
-    if (this.mousePos.dragStart) this.mousePos.dragEnd = { x: e.offsetX, y: e.offsetY };
+    if (m.dragStart) m.dragEnd = { x: e.offsetX, y: e.offsetY };
   }, false);
 
   return;

--- a/src/ctx.js
+++ b/src/ctx.js
@@ -1137,10 +1137,7 @@ const Ctx = function(origCtx, c) {
 	      if (!drawFn) {
 	        this.beginPath().save();
 	        this[fnName](...props);
-	        if (appliedStyles) {
-	          this.fill();
-	          this.stroke();
-	        }
+	        if (appliedStyles) this.fill().stroke();
 	        this.closePath().restore();
 	      } else {
 	        drawFn(...props);
@@ -1252,8 +1249,6 @@ const Ctx = function(origCtx, c) {
 
   // get object from an id (unique color)
   this.getObject = (id) => this.lookup(hex2rgb(id));
-
-  this.int2hex = int2hex;
 
   // event listeners
 

--- a/src/ctx.js
+++ b/src/ctx.js
@@ -963,6 +963,7 @@ const Ctx = function(origCtx, c) {
   // create an offscreen canvas, so we can:
   // * draw things to it, always with a unique color
   // * lookup a color to know which object/shape it refers to
+  // * use the above to "interactive canvas objects"
   //document.body.append(shadowCanvas);
   shadowCanvas.height = this.canvas.height;
   shadowCanvas.width = this.canvas.width;
@@ -1101,8 +1102,10 @@ const Ctx = function(origCtx, c) {
     }
   };
 
-  // interactive canvas
-
+  // interactive "canvas objects"
+  //
+  // This function generates "canvas objects" which can be
+  // hovered, clicked, dragged, etc, using `ctx.create`
   const generateCanvasObject = (fnName, props, drawFn) => {
 	  // Inside obj, `this` refers to the extended context
 	  const obj = {
@@ -1150,6 +1153,8 @@ const Ctx = function(origCtx, c) {
 	  return obj;
   }
 
+  // Allow creating create custom "canvas objects" with
+  // `ctx.create('shape', drawingFunc)`,
   this.create = (fnName, fn) => {
     // add this method to shadow canvas
     this.shadowCtx[fnName] = (...props) => fn.apply(this.shadowCtx, [...props]);
@@ -1158,9 +1163,8 @@ const Ctx = function(origCtx, c) {
     return this.create[fnName];
   }
 
-  // Add methods to the `ctx.create` object - one for each
-  // supported Ctx drawing method
-
+  // Add methods to the `ctx.create` API object - one for each
+  // existing ctx drawing method
   [...ctxMethods, ...extraMethodNames].forEach(fnName => {
   	// Create the ctx.create.rect() (etc) methods
   	// - each method:

--- a/src/ctx.js
+++ b/src/ctx.js
@@ -1122,13 +1122,9 @@ const Ctx = function(origCtx, c) {
 	      }
 	      if (!drawFn) {
 	        this.beginPath().save();
-	        this[fnName](...props)
-            .fill()
-            .stroke()
-            .closePath()
-            .restore();
+	        this[fnName](...props).fill().stroke().closePath().restore();
 	      } else {
-          drawFn(...props);
+	        drawFn(...props);
 	      }
 	      // draw `obj` to an off-screen canvas, using the unique color
 	      c.beginPath();

--- a/src/ctx.js
+++ b/src/ctx.js
@@ -1113,30 +1113,30 @@ const Ctx = function(origCtx, c) {
 	    props: [...props],
 	    update: (...props) => obj.props = [...props],
 	    draw: (styles) => {
-	      const props = obj.props;
+	      const props = obj.props,
+	            c = this.shadowCtx;
 	      if (styles) {
 	        for (let [key, value] of Object.entries(styles)) {
 	          this[key](value);
 	        }
 	      }
-	      if (typeof this[fnName] === 'function') {
-	        this.beginPath();
-	        this.save();
-	        this[fnName](...props);
-          this.fill();
-          this.stroke();
-          this.closePath();
-  	      this.restore();
+	      if (!drawFn) {
+	        this.beginPath().save();
+	        this[fnName](...props)
+            .fill()
+            .stroke()
+            .closePath()
+            .restore();
 	      } else {
           drawFn(...props);
 	      }
 	      // draw `obj` to an off-screen canvas, using the unique color
-	      this.shadowCtx.beginPath();
-	      this.shadowCtx.fillStyle = obj.id;
-	      this.shadowCtx[fnName](...props);
-	      this.shadowCtx.fill();
+	      c.beginPath();
+	      c.fillStyle = obj.id;
+	      c[fnName](...props);
+	      c.fill();
 	    },
-	    // event handlers
+	    // let user set event handlers
 	    onHover: fn => obj.hoverHandler = fn,
 	    onClick: fn => obj.clickHandler = fn,
 	    onRelease: fn => obj.releaseHandler = fn,
@@ -1251,10 +1251,9 @@ const Ctx = function(origCtx, c) {
       const { dragStart, dragEnd } = m;
       o.drag = false;
       if (dragStart && !dragEnd) {
-        // we started dragging, and we moved away from the original x,y location
+        o.drag = true;
         // run event handler
         if (o.onDrag && o.dragHandler) o.dragHandler(o);
-        o.drag = true;
       }
       // run event handler
       if (o.onHover && o.hoverHandler && !o.drag) {


### PR DESCRIPTION
## Interactive canvas improvements

- new: adds event handlers to "canvas objects": `myShape.on('click', someFunc)` (etc)
- new: use the `ctx.create()` API to create your own custom "interactive canvas objects"
- new: set any valid canvas styles as properties on your "canvas objects" before calling `myShape.draw()`
- new: optional syntax for using "canvas objects" - pass in params as a single object 

## Event handlers

```js
// new API - event handlers

// log an objects params on "click"," hover", "drag", "release"
myRect.on('click', props => console.log(props)); 
myRect.on('drag', props => console.log(props)); 
```

## Define custom "canvas objects"

```js
// new API - define custom "canvas objects" with `ctx.create(name, drawFunc)`

// define a new type of "interactive canvas object", called "coolShape"
ctx.create('coolShape', function(x, y, z, foo) {
  [ ctx, ctx.shadowCtx ].forEach(c => {
    // draw stuff here
    c.rect(x, y, w, h);
    c.lineTo(x, y);
    // etc
  });
});

// instantiate a "coolShape" object that can be hovered over, clicked, etc 
const myNewShape = ctx.create.coolShape(x, y, z, foo);

// use it the same as any other "canvas object" 
myNewShape.update(...);
myNewShape.draw(...);
myNewShape.on('hover', props => console.log(props));
```

## `myShape.adjust()`

- new canvas object method `.adjust()`: alternative way to update a "canvas object"

    ```js
    myStar.adjust(1, -1, 0)   // adjust the current props values by numbers given
    ```
## Attach styles to your "canvas objects" as props:

new API - alternative way to update "canvas object" styles:

```js
// define style properties on the canvas object itself, ready to draw later
myStar.lineWidth = 3;
myStar.fillStyle = '#c00';
// ...etc

myStar.draw(styleObj)      // `styleObj` is optional, but will override above styles, if given
```
## Alternative syntax, provides some extra features

new API - give "canvas objects" props as an object, instead of params list:

- the props will be added your "canvas object" as getters/setters:
  
  ```js
  // define as usual
  ctx.create('fooShape', (x, y, r) => {
    // draw your shape(s)
  });

  // instantiate with the props as an object, instead of a parameter list
  const myShape = ctx.create.fooShape({ x: 10, y: 10, r: 50 });
  myShape.props   // returns { x: 10, y: 10, r: 50 }

  // now we have extra getters/setters, one for each prop (x, y, r)
  myShape.r       // return myShape.props.r
  myShape.r = 50; // update myShape.props.r

  // note - because of how we created it, `myShape` only accepts 
  // an object of props, instead of parameter list
  myShape.update({ x: 0, y: 0, r: 50 }); // update all props
  myShape.update({ r: 50 });             // update specific props
  myShape.adjust({ r: 10 });             // adjust specific props
  ```

## Fixes

- fixed: apply "canvas object" styles (only) when needed

- fixed: don't draw "canvas object" on initial creation
